### PR TITLE
fix recursive prefix in __flatten_patterns_tree

### DIFF
--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -105,13 +105,14 @@ class UrlParserTest(TestCase):
             url(r'^', include(router.urls))
         )
         urls = patterns('',
-            url(r'api/', include(urls_app))
+            url(r'api/', include(urls_app)),
+            url(r'test/', include(urls_app))
         )
         urlparser = UrlParser()
         apis = urlparser.get_apis(urls)
 
-        for api in apis:
-            self.assertRegexpMatches(api['path'], r'^/api/')
+        self.assertEqual(sum(api['path'].find('api') != -1 for api in apis), 4)
+        self.assertEqual(sum(api['path'].find('test') != -1 for api in apis), 4)
 
     def test_get_api_callback(self):
         urlparser = UrlParser()

--- a/rest_framework_swagger/urlparser.py
+++ b/rest_framework_swagger/urlparser.py
@@ -123,8 +123,8 @@ class UrlParser(object):
                 if pattern.namespace in exclude_namespaces:
                     continue
 
-                prefix = prefix + pattern.regex.pattern
-                pattern_list.extend(self.__flatten_patterns_tree__(pattern.url_patterns, prefix, filter_path=filter_path))
+                pref = prefix + pattern.regex.pattern
+                pattern_list.extend(self.__flatten_patterns_tree__(pattern.url_patterns, pref, filter_path=filter_path))
 
         return pattern_list
 


### PR DESCRIPTION
Changed one line in urlparser.**flatten_pattern_tree** to allow recursion into lower levels which is necessary when DRFs new routers (which appear as URLResolvers including a list instead of a module) are used in an  app level urls.py. In the original version the prefix of the higher level was lost.

Did not add tests yet. Will improve if not merged by 8/16/2013

Falk
