### PR TITLE
Description for serializer fields

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -271,7 +271,7 @@ class DocumentationGenerator(object):
                 'name': name,
                 'dataType': data_type,
                 'allowableValues': allowable_values,
-                'description': '',  # Blank for now, no real way of getting field comments
+                'description': getattr(field, 'help_text', ''),
                 'defaultValue': getattr(field, 'default', None),
                 'required': getattr(field, 'required', None)
             })


### PR DESCRIPTION
The help_text of the serializer fields should be used for their description (previously this was always empty).
