### PR TITLE
Docstring keywords: required, body, file, overwrite

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -314,15 +314,18 @@ class DocumentationGenerator(object):
                         paramType = 'body'
                         dataType = 'file'
 
+                    required = '[required]' in description
+
                     description = description.replace('[body]', '')
                     description = description.replace('[file]', '')
+                    description = description.replace('[required]', '')
 
                     params.append({
                         'paramType': paramType,
                         'name': param[0].strip(),
                         'description': description.strip(),
                         'dataType': dataType,
-                        'required': False,
+                        'required': required,
                     })
 
         return params, overwrite


### PR DESCRIPTION
The keyword _[body]_ marks the parameter type as body. This generates a textarea that is sent as the message body.
The keyword _[required]_ marks the query string argument as required.
The keyword _[overwrite]_ overwrites all other parameter types - only the one in the docstring are used.

Example usage:

``` python
class PlacesPrefetchRequest(APIView):
    """
    Returns communities near your location
    [overwrite]
    Request Body -- Places as JSON [required] [body]
    """

```

I added [file] as a keyword to the docstring, which tells swagger that a multipart file should be uploaded.

``` python
class ProfilePictureView(APIView):
    """
    Multipart -- Image [required] [file]
    """
    parser_classes = (MultiPartParser,)

    def put(self, request, *args, **kwargs):
        files = request.FILES
        print "files", files
        return Response({})
```
