### PR TITLE
use JSONRendered for SwaggerResourcesView

### DIFF
--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -69,6 +69,8 @@ class SwaggerResourcesView(APIDocView):
 
 class SwaggerApiView(APIDocView):
 
+    renderer_classes = (JSONRenderer,)
+
     def get(self, request, path):
         apis = self.get_api_for_resource(path)
         generator = DocumentationGenerator()


### PR DESCRIPTION
The SwaggerResourcesView does not return JSON by default and swagger-codegen doesn't sepcifically negotiate a JSON response. Therefore, to make django-rest-swagger compatible with swagger-codegen, the resources view should return JSON by default and not the BrowseableAPIRenderer.
