### PR TITLE
Resolve default values if callable

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -4,7 +4,8 @@ from django.http import HttpRequest
 from rest_framework import viewsets
 
 from .introspectors import APIViewIntrospector, \
-    ViewSetIntrospector, BaseMethodIntrospector, IntrospectorHelper
+    ViewSetIntrospector, BaseMethodIntrospector, IntrospectorHelper, \
+    get_resolved_value
 
 
 class DocumentationGenerator(object):
@@ -112,7 +113,7 @@ class DocumentationGenerator(object):
                 'allowableValues': {
                     'min': getattr(field, 'min_length', None),
                     'max': getattr(field, 'max_length', None),
-                    'defaultValue': getattr(field, 'default', None),
+                    'defaultValue': get_resolved_value(field, 'default', None),
                     'readOnly': getattr(field, 'read_only', None),
                     'valueType': 'RANGE',
                 }

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -7,6 +7,13 @@ from django.contrib.admindocs.utils import trim_docstring
 from rest_framework.views import get_view_name, get_view_description
 
 
+def get_resolved_value(obj, attr, default=None):
+    value = getattr(obj, attr, default)
+    if callable(value):
+        value = value()
+    return value
+
+
 class IntrospectorHelper(object):
     __metaclass__ = ABCMeta
 
@@ -226,7 +233,7 @@ class BaseMethodIntrospector(object):
                 'dataType': data_type,
                 'allowableValues': allowable_values,
                 'description': getattr(field, 'help_text', ''),
-                'defaultValue': getattr(field, 'default', None),
+                'defaultValue': get_resolved_value(field, 'default'),
                 'required': getattr(field, 'required', None)
             })
 


### PR DESCRIPTION
Sometimes we want default values to be callables - for example datetime fields could always be current time.

Without resolving default callables we get JSON serialization errors.
