### PR TITLE
Fixes #63 missing starting letters from base path in resourses.

### DIFF
--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -78,6 +78,18 @@ class UrlParserTest(TestCase):
 
         self.assertEqual(len(self.url_patterns), len(apis))
 
+    def test_resources_starting_with_letters_from_base_path(self):
+        base_path = r'api/'
+        url_patterns = patterns('',
+                                url(r'test', MockApiView.as_view(), name='a test view'),
+                                url(r'pai_test', MockApiView.as_view(), name='start with letters a, p, i'),
+                                )
+        urls = patterns('', url(base_path, include(url_patterns)))
+        urlparser = UrlParser()
+        apis = urlparser.get_apis(urls)
+        resources = urlparser.get_top_level_apis(apis)
+        self.assertEqual(set(resources), set([base_path + url_pattern.regex.pattern for url_pattern in url_patterns]))
+
     def test_flatten_url_tree_with_filter(self):
         urlparser = UrlParser()
         apis = urlparser.get_apis(self.url_patterns, filter_path="a-view")

--- a/rest_framework_swagger/urlparser.py
+++ b/rest_framework_swagger/urlparser.py
@@ -70,7 +70,9 @@ class UrlParser(object):
         filtered_paths = set()
         base_path = self.__get_base_path__(root_paths)
         for path in root_paths:
-            resource = path.lstrip(base_path).split('/')[0]
+            if path.startswith(base_path):
+                path = path[len(base_path):]
+            resource = path.split('/')[0]
             filtered_paths.add(base_path + resource)
 
         return list(filtered_paths)


### PR DESCRIPTION
I have also stumbled upon this and did not see that someone already made pull request that fixes this. 
So, here's my solution for lstrip replacement. 
It starts searching from left side. It does not replace every occurrence of the base path. I've also written a test.  
