### PR TITLE
BUGFIX - Exclude_namespaces ignored when looking through URLs outside of root Level

### DIFF
--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -88,4 +88,5 @@ class SwaggerApiView(APIDocView):
 
     def get_api_for_resource(self, filter_path):
         urlparser = UrlParser()
-        return urlparser.get_apis(filter_path=filter_path)
+        return urlparser.get_apis(filter_path=filter_path,
+                exclude_namespaces=SWAGGER_SETTINGS.get('exclude_namespaces'))


### PR DESCRIPTION
Without passing in the exclude_namespaces, the APIs that should have been hidden were being shown.

The setting was being respected at the top level, but once you 'drill down' into the next level of the API the setting is nowhere to be found.
