### PR TITLE
Automatically get JSONRenderer from django rest framework settings

### DIFF
--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -34,10 +34,10 @@ from rest_framework_swagger import SWAGGER_SETTINGS
 from rest_framework.settings import api_settings
 
 try:
-    JSONRenderer = filter(
+    JSONRenderer = list(filter(
         lambda item: item.format == 'json',
         api_settings.DEFAULT_RENDERER_CLASSES,
-    )[0]
+    ))[0]
 except IndexError:
     from rest_framework.renderers import JSONRenderer
 


### PR DESCRIPTION
Instead of hardcoding rest_framework.renderers.JSONRenderer, get the first renderer with format == 'json' from rest_framework.settings.api_settings.DEFAULT_RENDERER_CLASSES. Fallback to JSONRenderer if none of the renderers match.

This mimics the way rest_framework selects a renderer during content negotiation.

This fixes #36.
