### PR TITLE
Pass fields help_text to swagger as field description.

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -119,8 +119,8 @@ class DocumentationGenerator(object):
                 }
             }
 
-            if getattr(field, 'help_text', False):
-                data[name]['description'] = getattr(field, 'help_text', '')
+            if hasattr(field, 'help_text'):
+                data[name]['description'] = field.help_text
 
         return data
 


### PR DESCRIPTION
I think the README states that the fields help_text would show in the generated documentation but they didn't.

I don't set the description if the help_text doesn't exist because swagger would add a colon if the description key is set.
