### PR TITLE
Moved response type checking to preserve explicit serializer registratio...

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -160,16 +160,16 @@ class DocumentationGenerator(object):
             callback=method_inspector.callback
         )
 
-        if doc_parser.get_response_type() is not None:
-            # Custom response class detected
-            return None
-
         if docstring_serializer is not None:
             self.explicit_serializers.add(docstring_serializer)
             serializer = docstring_serializer
 
         if doc_parser.should_omit_serializer():
             serializer = None
+
+        if doc_parser.get_response_type() is not None:
+            # Custom response class detected
+            return None
 
         return serializer
 


### PR DESCRIPTION
...n

This allows to reference explicitly added serializers via

```
serializer: myapp.serializers.CustomSerializer
```

as a model even if a custom response is defined using

```
type:
    myparam:
        description: My custom response param
        required: true
        type: string
```

See question here: https://github.com/marcgibbons/django-rest-swagger/pull/60#issuecomment-44956077

This does not affect any logic and tests pass.
