### PR TITLE
Add the possibility to use a custom method introspector class for any view.

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -43,15 +43,12 @@ class DocumentationGenerator(object):
                     method_introspector.get_http_method() == "OPTIONS":
                 continue  # No one cares. I impose JSON.
 
-            serializer = method_introspector.get_serializer_class()
-            serializer_name = IntrospectorHelper.get_serializer_name(serializer)
-
             operation = {
                 'httpMethod': method_introspector.get_http_method(),
                 'summary': method_introspector.get_summary(),
                 'nickname': method_introspector.get_nickname(),
                 'notes': method_introspector.get_notes(),
-                'responseClass': serializer_name,
+                'responseClass': method_introspector.get_response_class(),
             }
 
             parameters = method_introspector.get_parameters()

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -71,6 +71,17 @@ class BaseViewIntrospector(object):
         if hasattr(self.callback, 'get_serializer_class'):
             return self.callback().get_serializer_class()
 
+    def get_method_introspector_class(self):
+        """
+        Returns the method introspector class for the view. If a custom method
+        introspection is needed, it can be specified in the view's
+        get_method_introspector_class() method.
+        """
+        if hasattr(self.callback, 'get_method_introspector_class'):
+            return self.callback().get_method_introspector_class()
+        else:
+            return APIViewMethodIntrospector
+
     def get_description(self):
         """
         Returns the first sentence of the first line of the class docstring
@@ -89,6 +100,10 @@ class BaseMethodIntrospector(object):
 
     def get_serializer_class(self):
         return self.parent.get_serializer_class()
+
+    def get_response_class(self):
+        serializer = self.get_serializer_class()
+        return IntrospectorHelper.get_serializer_name(serializer)
 
     def get_summary(self):
         docs = self.get_docs()
@@ -265,7 +280,8 @@ class APIViewIntrospector(BaseViewIntrospector):
     def __iter__(self):
         methods = self.callback().allowed_methods
         for method in methods:
-            yield APIViewMethodIntrospector(self, method)
+            introspector_class = self.get_method_introspector_class()
+            yield introspector_class(self, method)
 
 
 class APIViewMethodIntrospector(BaseMethodIntrospector):


### PR DESCRIPTION
In a project, I have implemented custom additional http methods, and the automatically generated responseClass and method parameters did not suit me. To work around this, I wrote a patch to be able to use a custom APIViewMethodIntrospector for any view.

Indeed, my need was very specific, yet the solution is quite generic, so i thought it might be worth merging.

As an exemple, if you have a UserList view for which you have a specific need :

    class UserList(generics.ListCreateAPIView):
        def get_method_introspector_class(self):
            return UserMethodIntrospector

    from rest_framework_swagger.introspectors import APIViewMethodIntrospector
    class TestMethodIntrospector(APIViewMethodIntrospector):
        def get_parameters(self):
            if self.get_http_method() != 'CUSTOM':
                return super(TestMethodIntrospector, self).get_parameters()

            params = []
            # do something with params
            return params

        def get_response_class(self):
            if self.get_http_method() != 'CUSTOM':
                return super(TestMethodIntrospector, self).get_response_class()

            # return a custom reponse class
            return None