### PR TITLE
Python 3 fixes

### DIFF
--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -763,7 +763,7 @@ class YAMLDocstringParser(object):
         Merges parameters lists by key
         """
         merged = OrderedDict()
-        for item in params1 + params2:
+        for item in list(params1) + list(params2):
             merged[item[key]] = item
 
         return [val for (_, val) in merged.items()]


### PR DESCRIPTION
These changes make the develop branch work on Python 3.3+.
