### PR TITLE
display help_text and choices

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -292,7 +292,7 @@ class DocumentationGenerator(object):
                 f['maximum'] = max_val
 
             # ENUM options
-            if field.type_label == 'multiple choice' \
+            if field.type_label in ['multiple choice', 'choice'] \
                     and isinstance(field.choices, list):
                 f['enum'] = [k for k, v in field.choices]
 


### PR DESCRIPTION
Two small fixes: 

Issue #99: updates choice fields to work with newer django-rest-framework versions.

Issue #62: uses field's help_text to set description field in swagger (from gecko-landmarks:master, duplicates pull request #88)
