### PR TITLE
different request and response serializers  

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -154,7 +154,7 @@ class DocumentationGenerator(object):
 
         Serializer might be ignored if explicitly told in docstring
         """
-        serializer = method_inspector.get_serializer_class()
+        serializer = method_inspector.get_response_serializer_class()
 
         docstring_serializer = doc_parser.get_serializer_class(
             callback=method_inspector.callback
@@ -314,5 +314,11 @@ class DocumentationGenerator(object):
         return data
 
     def _get_serializer_class(self, callback):
+        if hasattr(callback, 'get_response_serializer_class'):
+            return callback().get_response_serializer_class()
+
+        if hasattr(callback, 'response_serializer_class'):
+            return callback().response_serializer_class
+
         if hasattr(callback, 'get_serializer_class'):
             return callback().get_serializer_class()

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -82,6 +82,20 @@ class BaseViewIntrospector(object):
         if hasattr(self.callback, 'get_serializer_class'):
             return self.callback().get_serializer_class()
 
+    def get_response_serializer_class(self):
+        if hasattr(self.callback, 'get_response_serializer_class'):
+            return self.callback().get_response_serializer_class()
+
+        if hasattr(self.callback, 'response_serializer_class'):
+            return self.callback().response_serializer_class
+
+    def get_request_serializer_class(self):
+        if hasattr(self.callback, 'get_request_serializer_class'):
+            return self.callback().get_request_serializer_class()
+
+        if hasattr(self.callback, 'request_serializer_class'):
+            return self.callback().request_serializer_class
+
     def get_description(self):
         """
         Returns the first sentence of the first line of the class docstring
@@ -111,6 +125,16 @@ class BaseMethodIntrospector(object):
         if serializer is None:
             serializer = self.parent.get_serializer_class()
         return serializer
+
+    def get_response_serializer_class(self):
+        parser = YAMLDocstringParser(docstring=self.get_docs())
+        serializer = parser.get_serializer_class(self.callback)
+        if serializer is None:
+            serializer = self.parent.get_response_serializer_class() or self.parent.get_serializer_class()
+        return serializer
+
+    def get_request_serializer_class(self):
+        return self.parent.get_request_serializer_class()
 
     def get_summary(self):
         docs = self.get_docs()
@@ -196,7 +220,7 @@ class BaseMethodIntrospector(object):
         return getattr(self.callback, method).__doc__
 
     def build_body_parameters(self):
-        serializer = self.get_serializer_class()
+        serializer = self.get_request_serializer_class() or self.get_serializer_class()
         serializer_name = IntrospectorHelper.get_serializer_name(serializer)
 
         if serializer_name is None:
@@ -230,7 +254,7 @@ class BaseMethodIntrospector(object):
         Builds form parameters from the serializer class
         """
         data = []
-        serializer = self.get_serializer_class()
+        serializer = self.get_request_serializer_class() or self.get_serializer_class()
 
         if serializer is None:
             return data


### PR DESCRIPTION
## Successor of #19

It is now possible to use different serializers for the request and the response. 
I introduced _request_serializer_class_ and _response_serializer_class_ attributes. If they are not found, it still falls back to _serializer_class_

``` python
class PlacesPrefetchRequest(APIView):
    """
    Prefetch places
    """

    request_serializer_class = serializers.SimplePlacesSerializer
    response_serializer_class = serializers.PlacesSerializer

    def post(self, request, *args, **kwargs):
        [...]
```
