### PR TITLE
Preserve the order of fields as declared in serializers

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -122,8 +122,8 @@ class DocumentationGenerator(object):
             # no readonly fields
             w_name = "Write{serializer}".format(serializer=serializer_name)
 
-            w_properties = dict((k, v) for k, v in data['fields'].items()
-                                if k not in data['read_only'])
+            w_properties = OrderedDict((k, v) for k, v in data['fields'].items()
+                                       if k not in data['read_only'])
 
             models[w_name] = {
                 'id': w_name,
@@ -135,8 +135,8 @@ class DocumentationGenerator(object):
             # no write_only fields
             r_name = serializer_name
 
-            r_properties = dict((k, v) for k, v in data['fields'].items()
-                                if k not in data['write_only'])
+            r_properties = OrderedDict((k, v) for k, v in data['fields'].items()
+                                       if k not in data['write_only'])
 
             models[r_name] = {
                 'id': r_name,
@@ -257,7 +257,7 @@ class DocumentationGenerator(object):
             fields = serializer.get_fields()
 
         data = OrderedDict({
-            'fields': {},
+            'fields': OrderedDict(),
             'required': [],
             'write_only': [],
             'read_only': [],

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -324,6 +324,20 @@ class DocumentationGeneratorTest(TestCase):
         delta = datetime.timedelta(seconds=1)
         self.assertAlmostEqual(value, datetime.datetime.now(), delta=delta)
 
+    def test_get_models_ordering(self):
+        class SerializedAPI(ListCreateAPIView):
+            serializer_class = CommentSerializer
+
+        urlparser = UrlParser()
+        url_patterns = patterns('', url(r'my-api/', SerializedAPI.as_view()))
+        apis = urlparser.get_apis(url_patterns)
+
+        docgen = DocumentationGenerator()
+        models = docgen.get_models(apis)
+
+        self.assertIn('CommentSerializer', models)
+        self.assertEqual(list(models['CommentSerializer']['properties'].keys()), ["email", "content", "created"])
+
     def test_get_serializer_set(self):
         class SerializedAPI(ListCreateAPIView):
             serializer_class = CommentSerializer


### PR DESCRIPTION
based on #97 
