### PR TITLE
Don't try to import urlconf unless it's a string.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ djangorestframework==2.4.3
 nose==1.3.0
 ordereddict==1.1
 mock==1.0.1
+flake8==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ django-nose==1.2
 djangorestframework==2.4.3
 nose==1.3.0
 ordereddict==1.1
+mock==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ djangorestframework==2.4.3
 nose==1.3.0
 mock==1.0.1
 ordereddict==1.1
+six==1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,5 @@ coverage==3.6
 django-nose==1.2
 djangorestframework==2.4.3
 nose==1.3.0
-ordereddict==1.1
 mock==1.0.1
-flake8==2.3.0
+ordereddict==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ djangorestframework==2.4.3
 nose==1.3.0
 mock==1.0.1
 ordereddict==1.1
-six==1.9.0

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -95,7 +95,7 @@ class UrlParserTest(TestCase):
     def test_get_apis_urlconf_import(self):
         urlparser = UrlParser()
         urlconf = MockUrlconfModule(self.url_patterns)
-        with patch.dict('sys.modules', { 'mock_urls': urlconf }):
+        with patch.dict('sys.modules', {'mock_urls': urlconf}):
             apis = urlparser.get_apis(urlconf='mock_urls')
             for api in apis:
                 self.assertIn(api['pattern'], self.url_patterns)

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -1,4 +1,5 @@
 import datetime
+from mock import patch
 
 from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
 from django.conf import settings
@@ -56,6 +57,12 @@ class NonApiView(View):
     pass
 
 
+class MockUrlconfModule:
+    """ A mock of an `app.urls`-like module. """
+    def __init__(self, urlpatterns):
+        self.urlpatterns = urlpatterns
+
+
 class CommentSerializer(serializers.Serializer):
     email = serializers.EmailField()
     content = serializers.CharField(max_length=200)
@@ -82,7 +89,21 @@ class UrlParserTest(TestCase):
         # Overwrite settings with test patterns
         urls.urlpatterns = self.url_patterns
         apis = urlparser.get_apis()
+        for api in apis:
+            self.assertIn(api['pattern'], self.url_patterns)
 
+    def test_get_apis_urlconf_import(self):
+        urlparser = UrlParser()
+        urlconf = MockUrlconfModule(self.url_patterns)
+        with patch.dict('sys.modules', { 'mock_urls': urlconf }):
+            apis = urlparser.get_apis(urlconf='mock_urls')
+            for api in apis:
+                self.assertIn(api['pattern'], self.url_patterns)
+
+    def test_get_apis_urlconf_module(self):
+        urlparser = UrlParser()
+        urlconf = MockUrlconfModule(self.url_patterns)
+        apis = urlparser.get_apis(urlconf=urlconf)
         for api in apis:
             self.assertIn(api['pattern'], self.url_patterns)
 

--- a/rest_framework_swagger/urlparser.py
+++ b/rest_framework_swagger/urlparser.py
@@ -1,4 +1,5 @@
 import os
+import six
 
 from django.conf import settings
 from django.utils.importlib import import_module
@@ -20,7 +21,7 @@ class UrlParser(object):
         exclude_namespaces -- list of namespaces to ignore (optional)
         """
         if patterns is None and urlconf is not None:
-            if type(urlconf) in (str, unicode):
+            if isinstance(urlconf, six.string_types):
                 urls = import_module(urlconf)
             else:
                 urls = urlconf

--- a/rest_framework_swagger/urlparser.py
+++ b/rest_framework_swagger/urlparser.py
@@ -20,7 +20,7 @@ class UrlParser(object):
         exclude_namespaces -- list of namespaces to ignore (optional)
         """
         if patterns is None and urlconf is not None:
-            if type(urlconf) in ('str', 'unicode'):
+            if type(urlconf) in (str, unicode):
                 urls = import_module(urlconf)
             else:
                 urls = urlconf

--- a/rest_framework_swagger/urlparser.py
+++ b/rest_framework_swagger/urlparser.py
@@ -20,7 +20,10 @@ class UrlParser(object):
         exclude_namespaces -- list of namespaces to ignore (optional)
         """
         if patterns is None and urlconf is not None:
-            urls = import_module(urlconf)
+            if type(urlconf) in ('str', 'unicode'):
+                urls = import_module(urlconf)
+            else:
+                urls = urlconf
             patterns = urls.urlpatterns
         elif patterns is None and urlconf is None:
             urls = import_module(settings.ROOT_URLCONF)

--- a/rest_framework_swagger/urlparser.py
+++ b/rest_framework_swagger/urlparser.py
@@ -1,7 +1,6 @@
 import os
-import six
-
 from django.conf import settings
+from django.utils import six
 from django.utils.importlib import import_module
 from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
 from django.contrib.admindocs.views import simplify_regex

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,6 @@ deps =
     argh==0.23.2
     nose==1.3.0
     mock==1.0.1
-    six==1.9.0
     django-nose==1.2
     coverage==3.6
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ deps =
     argparse==1.2.1
     argh==0.23.2
     nose==1.3.0
+    mock==1.0.1
     django-nose==1.2
     coverage==3.6
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ deps =
     drf2.4.3: djangorestframework==2.4.3
     drf3.0.0: djangorestframework==3.0.0
     drf3.0.1: djangorestframework==3.0.1
-    py33-django1.5-drf{2.3.8,2.4.3}: six==1.9.0
     {py27,py32,py33,py34}-django{1.5,1.6,1.7}-drf{2.3.8,2.4.3}: PyYAML==3.10
     {py27,py32,py33,py34}-django{1.5,1.6,1.7}-drf{2.3.8,2.4.3,3.0.0,3.0.1}: Markdown==2.5.1
     py26-django{1.5,1.6}-drf{2.3.8,2.4.3,3.0.0,3.0.1}: Markdown==2.1.1

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     drf2.4.3: djangorestframework==2.4.3
     drf3.0.0: djangorestframework==3.0.0
     drf3.0.1: djangorestframework==3.0.1
-    py33-django1.5-drf{2.3.8,2.4.3}: six==1.7.2
+    py33-django1.5-drf{2.3.8,2.4.3}: six==1.9.0
     {py27,py32,py33,py34}-django{1.5,1.6,1.7}-drf{2.3.8,2.4.3}: PyYAML==3.10
     {py27,py32,py33,py34}-django{1.5,1.6,1.7}-drf{2.3.8,2.4.3,3.0.0,3.0.1}: Markdown==2.5.1
     py26-django{1.5,1.6}-drf{2.3.8,2.4.3,3.0.0,3.0.1}: Markdown==2.1.1
@@ -24,6 +24,7 @@ deps =
     argh==0.23.2
     nose==1.3.0
     mock==1.0.1
+    six==1.9.0
     django-nose==1.2
     coverage==3.6
 


### PR DESCRIPTION
When parsing urls, if `request.urlconf` is already a module (eg. when using django-subdomains) we shouldn't try to import it.

This checks if `urlconf` is a string before trying to import it.