### PR TITLE
Auto-detect NullBooleanField as boolean value

### DIFF
--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -418,6 +418,8 @@ def get_data_type(field):
         return field.type_label
     elif isinstance(field, fields.BooleanField):
         return 'boolean'
+    elif isinstance(field, fields.NullBooleanField):
+        return 'boolean'
     elif isinstance(field, fields.URLField):
         return 'url'
     elif isinstance(field, fields.SlugField):


### PR DESCRIPTION
NullBooleanFields are not automatically detected as boolean fields. With this fix, the introspector will detect such fields as boolean.
NullBooleanField is a standard field in Django REST Framework (refer to http://www.django-rest-framework.org/api-guide/fields/#nullbooleanfield). It corresponds to Django's NullBooleanField, which is present at least since Django 1.3 (checked Django 1.3 documentation for this field).