### PR TITLE
Fixed docstring summary parser

### DIFF
--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -107,7 +107,7 @@ class IntrospectorHelper(object):
         Returns the first sentence of the first line of the class docstring
         """
         description = strip_tags(get_view_description(
-            callback, html=True, docstring=docstring)) \
+            callback, html=False, docstring=docstring)) \
             .split("\n")[0].split(".")[0]
         return description
 


### PR DESCRIPTION
This fixes a bug where the endpoint summary parser erroneously consumes the entire view or class docstring.