### PR TITLE
Support manual setting of protocol and base_path

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -21,7 +21,9 @@ Example:
         'api_key': '', 
         'is_authenticated': False,  
         'is_superuser': False, 
-        'permission_denied_handler': None, 
+        'permission_denied_handler': None,
+	'protocol': http',
+	'base_path':'helloreverb.com/docs' 
         'info': {
             'contact': 'apiteam@wordnik.com',
             'description': 'This is a sample server Petstore server. '
@@ -59,6 +61,13 @@ api_key
 an api key
 
 Defaults to :code:`''`
+
+base_path
+-----------------------
+
+the url to where your main Swagger documentation page will live without the protocol. Optional.
+
+If not provided, it will generate the base_path from the :code:`request.get_host()` method.
 
 doc_expansion
 -----------------------
@@ -133,3 +142,10 @@ token_type
 Overrides authorization token type.
 
 Default: :code:`'Token'`
+
+protocol
+--------
+
+The protocol of the application, e.g 'http' or 'https'. Optional
+
+Defaults to 'https' if the :code:`request.is_secure()` returns true, otherwise defaults to 'http'

--- a/rest_framework_swagger/apidocview.py
+++ b/rest_framework_swagger/apidocview.py
@@ -7,7 +7,7 @@ class APIDocView(APIView):
 
     def initial(self, request, *args, **kwargs):
         self.permission_classes = (self.get_permission_class(request),)
-        protocol = "https" if request.is_secure() else "http"
+        protocol = SWAGGER_SETTINGS.get('protocol', '') or ("https" if request.is_secure() else "http")
         self.host = request.build_absolute_uri()
         self.api_path = SWAGGER_SETTINGS['api_path']
         self.api_full_uri = "%s://%s%s" % (protocol, request.get_host(), self.api_path)


### PR DESCRIPTION
While using DRS in our setup, we ran into issue with the protocol and base_path returning the wrong values with our environment.

This was our setup:

Django Application running on EC2 via a Virtual Environment with Gunicorn, NGINX forced to connect over HTTP.

I've added two optional settings for 'protocol' and 'base_path' that can be provided to manually set these fields for people running similar setups to ours.

I believe this might address issues 83 and 77.