### PR TITLE
Fix wrong grouping of resources

### DIFF
--- a/rest_framework_swagger/urlparser.py
+++ b/rest_framework_swagger/urlparser.py
@@ -1,3 +1,4 @@
+import re
 import os
 from django.conf import settings
 from django.utils import six
@@ -107,7 +108,7 @@ class UrlParser(object):
         path = simplify_regex(prefix + pattern.regex.pattern)
 
         if filter_path is not None:
-            if filter_path not in path:
+            if re.match('^/?%s(/.*)?$' % filter_path, path) is None:
                 return None
 
         path = path.replace('<', '{').replace('>', '}')

--- a/rest_framework_swagger/urlparser.py
+++ b/rest_framework_swagger/urlparser.py
@@ -108,7 +108,7 @@ class UrlParser(object):
         path = simplify_regex(prefix + pattern.regex.pattern)
 
         if filter_path is not None:
-            if re.match('^/?%s(/.*)?$' % filter_path, path) is None:
+            if re.match('^/?%s(/.*)?$' % re.escape(filter_path), path) is None:
                 return None
 
         path = path.replace('<', '{').replace('>', '}')


### PR DESCRIPTION
e.g. when the following API endpoints exist:
/cigars/
/cigars/{pk}/
/cigars_artisan/
/cigars_artisan/{pk}/

all four are wrongfully listed in the cigars namespace