### PR TITLE
Pass 'suffix' to DRF's get_view_name, resolve view name getter via DRF's VIEW_NAME_FUNCTION setting.

### DIFF
--- a/docs/source/misc.rst
+++ b/docs/source/misc.rst
@@ -16,3 +16,24 @@ Add to your settings:
     REST_FRAMEWORK = {
         'VIEW_DESCRIPTION_FUNCTION': 'rest_framework_swagger.views.get_restructuredtext'
     }
+
+Swagger 'nickname' attribute
+-----------------
+By default, django-rest-swagger uses django-rest-framework's get_view_name to resolve the `nickname` attribute
+of a Swagger operation. You can specify an alternative function for `nickname` resolution using the following setting:
+
+.. code-block:: python
+
+    REST_FRAMEWORK = {
+        'VIEW_NAME_FUNCTION': 'module.path.to.custom.view.name.function'
+    }
+
+This function should use the following signature:
+
+.. code-block:: python
+
+    view_name(cls, suffix=None)
+
+-:code:`cls` The view class providing the operation.
+
+-:code:`suffix` The string name of the class method which is providing the operation.

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -239,7 +239,7 @@ class BaseMethodIntrospector(object):
 
     def get_nickname(self):
         """ Returns the APIView's nickname """
-        return get_view_name(self.callback).replace(' ', '_')
+        return get_view_name(self.callback, self.method).replace(' ', '_')
 
     def get_notes(self):
         """

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -16,7 +16,6 @@ from django.contrib.admindocs.utils import trim_docstring
 from django.utils.encoding import smart_text
 
 import rest_framework
-from rest_framework.views import get_view_name
 from rest_framework import viewsets
 from rest_framework.compat import apply_markdown
 from rest_framework.utils import formatting
@@ -239,7 +238,8 @@ class BaseMethodIntrospector(object):
 
     def get_nickname(self):
         """ Returns the APIView's nickname """
-        return get_view_name(self.callback, self.method).replace(' ', '_')
+        return rest_framework.settings.api_settings \
+            .VIEW_NAME_FUNCTION(self.callback, self.method).replace(' ', '_')
 
     def get_notes(self):
         """


### PR DESCRIPTION
DRS currently resolves the swagger 'nickname' attribute by passing a view's class to DRF's get_view_name. Because many methods share the same class, these methods receive identical nickname's; the swagger spec requires unique view names.

The get_view_name function allows an optional 'suffix' parameter to distinguish between view methods within a common class. The pull request provides the method name as this 'suffix', and consequently produces unique nicknames.

This pull request also uses DRF's VIEW_NAME_FUNCTION setting to resolve the view name getter function, allowing users to specify their own view name getter using DRF's settings.

Closes #230.