### PR TITLE
Keep the leading slash when filtering apis

### DIFF
--- a/rest_framework_swagger/urlparser.py
+++ b/rest_framework_swagger/urlparser.py
@@ -43,7 +43,7 @@ class UrlParser(object):
         filtered_list = []
 
         for api in apis:
-            if filter_path in api['path'].strip('/'):
+            if '/' + filter_path in api['path']:
                 filtered_list.append(api)
 
         return filtered_list


### PR DESCRIPTION
We have two APIs in our "frontend" project: frtapi for AJAX calls and api for REST calls. Since django-rest-swagger filters without the leading slash, `"api" in "frtapi/endpoint"` returns `True`. Our name choices may be questionable, but I believe using the leading slash can only be better. Please correct me if I'm wrong.