### PR TITLE
Ensure namespace is not None before comparison

### DIFF
--- a/rest_framework_swagger/urlparser.py
+++ b/rest_framework_swagger/urlparser.py
@@ -141,7 +141,7 @@ class UrlParser(object):
 
             elif isinstance(pattern, RegexURLResolver):
 
-                if pattern.namespace in exclude_namespaces:
+                if pattern.namespace is not None and pattern.namespace in exclude_namespaces:
                     continue
 
                 pref = prefix + pattern.regex.pattern


### PR DESCRIPTION
`None in ['something']` raises a `TypeError`, and Django URL namespaces can be `None`.