### PR TITLE
exclude_namespaces also excludes plain url names

### DIFF
--- a/rest_framework_swagger/urlparser.py
+++ b/rest_framework_swagger/urlparser.py
@@ -138,6 +138,9 @@ class UrlParser(object):
                 if endpoint_data is None:
                     continue
 
+                if pattern.name in exclude_namespaces:
+                    continue
+
                 pattern_list.append(endpoint_data)
 
             elif isinstance(pattern, RegexURLResolver):


### PR DESCRIPTION
Ran into an issue where one of my more exotic APIViews was incompatible with rest_swagger's introspection.

I wanted to exclude just this URL, but found that the `SWAGGER_SETTINGS['exclude_namespaces']` only checked entire namespaces.

Added a couple of lines to urlparser.py and it works like a charm.