### PR TITLE
Replaced django.utils.importlib with python importlib

### DIFF
--- a/rest_framework_swagger/urlparser.py
+++ b/rest_framework_swagger/urlparser.py
@@ -1,8 +1,9 @@
 import re
 import os
+from importlib import import_module
+
 from django.conf import settings
 from django.utils import six
-from django.utils.importlib import import_module
 from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
 from django.contrib.admindocs.views import simplify_regex
 


### PR DESCRIPTION
django.utils.importlib will be removed in Django 1.9