### PR TITLE
Allow to specify custom Swagger model name for serializers

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -125,8 +125,10 @@ class DocumentationGenerator(object):
             w_properties = OrderedDict((k, v) for k, v in data['fields'].items()
                                        if k not in data['read_only'])
 
+            forced_name = getattr(serializer, "_{0}__swagger_model_write_name".format(serializer_name), None)
+
             models[w_name] = {
-                'id': w_name,
+                'id': forced_name if forced_name else w_name,
                 'required': [i for i in data['required'] if i in w_properties.keys()],
                 'properties': w_properties,
             }
@@ -138,8 +140,10 @@ class DocumentationGenerator(object):
             r_properties = OrderedDict((k, v) for k, v in data['fields'].items()
                                        if k not in data['write_only'])
 
+            forced_name = getattr(serializer, "_{0}__swagger_model_read_name".format(serializer_name), None)
+
             models[r_name] = {
-                'id': r_name,
+                'id': forced_name if forced_name else r_name,
                 'required': [i for i in r_properties.keys()],
                 'properties': r_properties,
             }

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -281,16 +281,6 @@ class BaseMethodIntrospector(object):
         form_params = self.build_form_parameters()
         query_params = self.build_query_parameters()
 
-        new_form_params = []
-        if form_params and path_params:
-            for param in form_params:
-                for pparam in path_params:
-                    if param['name'] == pparam['name']:
-                        pparam['description']  = param['description']
-                    else:
-                        new_form_params.append(param)
-        form_params = new_form_params
-
         if path_params:
             params += path_params
 

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -281,6 +281,16 @@ class BaseMethodIntrospector(object):
         form_params = self.build_form_parameters()
         query_params = self.build_query_parameters()
 
+        new_form_params = []
+        if form_params and path_params:
+            for param in form_params:
+                for pparam in path_params:
+                    if param['name'] == pparam['name']:
+                        pparam['description']  = param['description']
+                    else:
+                        new_form_params.append(param)
+        form_params = new_form_params
+
         if path_params:
             params += path_params
 


### PR DESCRIPTION
This commit allows to specify "read" and "write" model names with serializer static field:

    class MySerializer(serializers.ModelSerializer):
        __swagger_model_read_name = 'MyModel'
        __swagger_model_write_name = 'MyModelResponse'

This scheme was selected according to [PEP 8 - Style Guide For Python Code](http://www.python.org/dev/peps/pep-0008/#naming-conventions):

    __double_leading_underscore: when naming a class attribute, invokes name mangling (inside class FooBar, __boo becomes _FooBar__boo; see below).