### PR TITLE
Exclude HiddenField from parsed fields

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -283,6 +283,8 @@ class DocumentationGenerator(object):
                 data['required'].append(name)
 
             data_type = get_data_type(field) or 'string'
+            if data_type == 'hidden':
+                continue
 
             # guess format
             data_format = 'string'

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -382,6 +382,8 @@ class BaseMethodIntrospector(object):
                 continue
 
             data_type = get_data_type(field) or 'string'
+            if data_type == 'hidden':
+                continue
 
             # guess format
             data_format = 'string'
@@ -466,6 +468,8 @@ def get_data_type(field):
         return 'file upload'
     elif isinstance(field, fields.CharField):
         return 'string'
+    elif rest_framework.VERSION >= '3.0.0' and isinstance(field, fields.HiddenField):
+        return 'hidden'
     else:
         return 'string'
 


### PR DESCRIPTION
Hello awesome django-rest-swagger folks!  I noticed that HiddenFields are showing up in the generated swagger documentation.  Here's a PR that removes them.

Thanks,
Jason