### PR TITLE
Also allow for excluding nested urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Release Notes:
 
-### v0.3.1 (June 6, 2015)
+### v0.3.2 (June 5, 2015)
+* un-add settings overrides for api protocols
+* support for django_filters
+
+### v0.3.1 (June 4, 2015)
 * add settings overrides for api urls
 * allow bash command "long options" in notes 
 

--- a/rest_framework_swagger/__init__.py
+++ b/rest_framework_swagger/__init__.py
@@ -1,4 +1,4 @@
-VERSION = '0.3.1'
+VERSION = '0.3.2'
 
 DEFAULT_SWAGGER_SETTINGS = {
     'exclude_namespaces': [],

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -20,6 +20,9 @@ class DocumentationGenerator(object):
     # Response classes defined in docstrings
     explicit_response_types = dict()
 
+    #names of value contraints used in REST serializers
+    contraint_names = ["max_length", "min_length", "max_val", "min_val"]
+
     def generate(self, apis):
         """
         Returns documentation for a list of APIs
@@ -290,9 +293,13 @@ class DocumentationGenerator(object):
             description = getattr(field, 'help_text', '')
             if not description or description.strip() == '':
                 description = None
+            #custom variable to add constraints to swagger pages
+            constraints = [(k, getattr(field, k, None)) for k in self.contraint_names]
+            c_string = ", ".join(["{k}: {v}".format(k=k, v=v) for k, v in constraints if v is not None])
+            type_description = "{t}; {c}".format(t=data_type, c=c_string) if len(c_string) else data_type
             f = {
                 'description': description,
-                'type': data_type,
+                'type': type_description, #custom
                 'format': data_format,
                 'required': getattr(field, 'required', False),
                 'defaultValue': get_default_value(field),

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -162,4 +162,4 @@ class SwaggerApiView(APIDocView):
     def get_api_for_resource(self, filter_path):
         urlparser = UrlParser()
         urlconf = getattr(self.request, "urlconf", None)
-        return urlparser.get_apis(urlconf=urlconf, filter_path=filter_path, exclude_namespaces=SWAGGER_SETTINGS.get('exclude_namespaces'))
+        return urlparser.get_apis(urlconf=urlconf, filter_path=filter_path, exclude_namespaces=rfs.SWAGGER_SETTINGS.get('exclude_namespaces'))


### PR DESCRIPTION
This fix allows for nested urls be excluded.
Before this fix I could only exclude a url if it was on the root of the API