### PR TITLE
Add optional support for django_filters third party package

### DIFF
--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -3,6 +3,7 @@
 """Handles the instrospection of REST Framework Views and ViewSets."""
 
 import inspect
+import itertools
 import re
 import yaml
 import importlib
@@ -380,10 +381,17 @@ class BaseMethodIntrospector(object):
         if (filter_class is not None and
                 issubclass(filter_class, django_filters.FilterSet)):
             for name, filter_ in filter_class.base_filters.items():
-                params.append({'paramType': 'query',
-                               'name': name,
-                               'description': filter_.label,
-                               'dataType': ''})
+                parameter = {'paramType': 'query',
+                             'name': name,
+                             'description': filter_.label,
+                             'dataType': ''}
+                multiple_choices = filter_.extra.get('choices', {})
+                if multiple_choices:
+                    parameter['enum'] = [choice[0] for choice
+                                         in itertools.chain(multiple_choices)]
+                    parameter['dataType'] = 'enum'
+                params.append(parameter)
+
         return params
 
     def build_form_parameters(self):

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -884,6 +884,12 @@ class ViewSetMethodIntrospectorTests(TestCase):
             username = django_filters.CharFilter(
                 label='Username of User',
             )
+            choices = django_filters.ChoiceFilter(
+                name='first_name',
+                label='Choices of possible first names',
+                choices=(('foo', 'Foo'),
+                         ('bar', 'Bar')
+                         ))
 
         class MyViewSet(ModelViewSet):
             model = User
@@ -898,7 +904,14 @@ class ViewSetMethodIntrospectorTests(TestCase):
                            'name': 'username',
                            'description': 'Username of User',
                            'dataType': ''
-                           }])
+                           },
+                          {'paramType': 'query',
+                           'name': 'choices',
+                           'description': 'Choices of possible first names',
+                           'enum': ['foo', 'bar'],
+                           'dataType': 'enum'
+                           }
+                          ])
 
     def test_get_summary_empty(self):
         class MyViewSet(ModelViewSet):

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -11,6 +11,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.importlib import import_module
 from django.views.generic import View
+import django_filters
 
 from rest_framework.views import APIView
 from rest_framework.generics import ListCreateAPIView
@@ -877,6 +878,27 @@ class ViewSetMethodIntrospectorTests(TestCase):
         self.assertEqual(0, len(page))
         page_by = [p for p in params if p['name'] == 'page_this_by']
         self.assertEqual(0, len(page_by))
+
+    def test_builds_parameters_from_django_filters(self):
+        class UserFilter(django_filters.FilterSet):
+            username = django_filters.CharFilter(
+                label='Username of User',
+            )
+
+        class MyViewSet(ModelViewSet):
+            model = User
+            serializer_class = CommentSerializer
+            filter_class = UserFilter
+
+        class_introspector = self.make_view_introspector(MyViewSet)
+        introspector = get_introspectors(class_introspector)['list']
+        params = introspector.build_query_parameters_from_django_filters()
+        self.assertEqual(params,
+                         [{'paramType': 'query',
+                           'name': 'username',
+                           'description': 'Username of User',
+                           'dataType': ''
+                           }])
 
     def test_get_summary_empty(self):
         class MyViewSet(ModelViewSet):

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ deps =
     mock==1.0.1
     django-nose==1.4
     coverage==3.6
+    django-filter==0.10.0
 
 [testenv:py27-flake8]
 deps =


### PR DESCRIPTION
Will introspect `django_filters.FilterSet` instances,
and create `query` paramType automatically.