### PR TITLE
Remove 'protocol' settings

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -22,7 +22,6 @@ Example:
         'is_authenticated': False,  
         'is_superuser': False, 
         'permission_denied_handler': None,
-	'protocol': http',
 	'base_path':'helloreverb.com/docs' 
         'info': {
             'contact': 'apiteam@wordnik.com',
@@ -142,10 +141,3 @@ token_type
 Overrides authorization token type.
 
 Default: :code:`'Token'`
-
-protocol
---------
-
-The protocol of the application, e.g 'http' or 'https'. Optional
-
-Defaults to 'https' if the :code:`request.is_secure()` returns true, otherwise defaults to 'http'

--- a/rest_framework_swagger/apidocview.py
+++ b/rest_framework_swagger/apidocview.py
@@ -7,10 +7,9 @@ class APIDocView(APIView):
 
     def initial(self, request, *args, **kwargs):
         self.permission_classes = (self.get_permission_class(request),)
-        protocol = SWAGGER_SETTINGS.get('protocol', '') or ("https" if request.is_secure() else "http")
         self.host = request.build_absolute_uri()
         self.api_path = SWAGGER_SETTINGS['api_path']
-        self.api_full_uri = "%s://%s%s" % (protocol, request.get_host(), self.api_path)
+        self.api_full_uri = request.build_absolute_uri(self.api_path)
 
         return super(APIDocView, self).initial(request, *args, **kwargs)
 

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -84,15 +84,7 @@ def parse_json(response):
     return json
 
 
-https_SETTINGS = {
-    'SWAGGER_SETTINGS': {
-        'protocol': 'https'
-    }
-}
-
-
-@override_settings(**https_SETTINGS)
-class OverrideProtocolTest(TestCase):
+class HTTPSTest(TestCase):
     def setUp(self):
         self.url_patterns = patterns(
             '',
@@ -103,7 +95,8 @@ class OverrideProtocolTest(TestCase):
     def test_swagger_view(self):
         urls = import_module(settings.ROOT_URLCONF)
         urls.urlpatterns = self.url_patterns
-        response = self.client.get("/swagger/")
+        response = self.client.get("/swagger/",
+                                   **{'wsgi.url_scheme': 'https'})
         content = response.content.decode()
         self.assertIn("url: 'https", content)
 
@@ -111,7 +104,9 @@ class OverrideProtocolTest(TestCase):
         from django.utils.six.moves.urllib import parse
         urls = import_module(settings.ROOT_URLCONF)
         urls.urlpatterns = self.url_patterns
-        response = self.client.get("/swagger/api-docs/")
+        response = self.client.get("/swagger/api-docs/",
+                                   **{'wsgi.url_scheme': 'https',
+                                      'SERVER_PORT': 443})
         json = parse_json(response)
         base_url = parse.urlparse(json['basePath'])
         self.assertEqual('https', base_url.scheme)

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -41,13 +41,13 @@ def get_restructuredtext(view_cls, html=False):
 
 
 def get_full_base_path(request):
-    protocol = rfs.SWAGGER_SETTINGS.get('protocol', 'http')
-    if 'base_path' in rfs.SWAGGER_SETTINGS:
-        base_path = rfs.SWAGGER_SETTINGS.get('base_path', '')
-        return ("%s://%s" % (protocol, base_path.rstrip('/'))).rstrip('/')
+    try:
+        base_path = rfs.SWAGGER_SETTINGS['base_path']
+    except KeyError:
+        return request.build_absolute_uri(request.path).rstrip('/')
     else:
-        return ('%s://%s%s' % (protocol,
-                               request.get_host(), request.path)).rstrip('/')
+        protocol = 'https' if request.is_secure() else 'http'
+        return '{0}://{1}'.format(protocol, base_path.rstrip('/'))
 
 
 class SwaggerUIView(View):
@@ -124,13 +124,14 @@ class SwaggerResourcesView(APIDocView):
         })
 
     def get_base_path(self):
-        protocol = rfs.SWAGGER_SETTINGS.get('protocol', 'http')
-        if 'base_path' in rfs.SWAGGER_SETTINGS:
-            base_path = rfs.SWAGGER_SETTINGS.get('base_path', '')
-            return ("%s://%s/api-docs" % (protocol, base_path.rstrip('/')))
+        try:
+            base_path = rfs.SWAGGER_SETTINGS['base_path']
+        except KeyError:
+            return self.request.build_absolute_uri(
+                self.request.path).rstrip('/')
         else:
-            return ('%s://%s%s' % (protocol, self.request.get_host(),
-                                   self.request.path)).rstrip('/')
+            protocol = 'https' if self.request.is_secure() else 'http'
+            return '{0}://{1}/{2}'.format(protocol, base_path, 'api-docs')
 
     def get_resources(self):
         urlparser = UrlParser()


### PR DESCRIPTION
Always rely on `request.is_secure()` instead

fixes #286 