### PR TITLE
Restrict filtering for list views

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -29,34 +29,30 @@ class DocumentationGenerator(object):
             api_docs.append({
                 'description': IntrospectorHelper.get_summary(api['callback']),
                 'path': api['path'],
-                'operations': self.get_operations(api, apis),
+                'operations': self.get_operations(api),
             })
 
         return api_docs
 
-    def get_introspector(self, api, apis):
+    def get_introspector(self, api):
         path = api['path']
         pattern = api['pattern']
         callback = api['callback']
         if callback.__module__ == 'rest_framework.decorators':
             return WrappedAPIViewIntrospector(callback, path, pattern)
         elif issubclass(callback, viewsets.ViewSetMixin):
-            patterns = [a['pattern'] for a in apis
-                        if a['callback'] == callback]
-            return ViewSetIntrospector(callback, path, pattern,
-                                       patterns=patterns)
+            return ViewSetIntrospector(callback, path, pattern)
         else:
             return APIViewIntrospector(callback, path, pattern)
 
-    def get_operations(self, api, apis=None):
+    def get_operations(self, api):
         """
         Returns docs for the allowed methods of an API endpoint
         """
-        if apis is None:
-            apis = [api]
+
         operations = []
 
-        introspector = self.get_introspector(api, apis)
+        introspector = self.get_introspector(api)
 
         for method_introspector in introspector:
             if not isinstance(method_introspector, BaseMethodIntrospector) or \
@@ -217,7 +213,7 @@ class DocumentationGenerator(object):
         serializers = set()
 
         for api in apis:
-            introspector = self.get_introspector(api, apis)
+            introspector = self.get_introspector(api)
             for method_introspector in introspector:
                 serializer = self._get_method_serializer(method_introspector)
                 if serializer is not None:

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -600,10 +600,10 @@ class ViewSetIntrospector(BaseViewIntrospector):
 
         try:
             x = closure_n_code(callback)
+            callback = get_closure_var(callback)
 
             while getattr(x.code, 'co_name') != 'view':
                 # lets unwrap!
-                callback = get_closure_var(callback)
                 x = closure_n_code(callback)
 
             freevars = x.code.co_freevars

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -581,9 +581,10 @@ class ViewSetIntrospector(BaseViewIntrospector):
         self.patterns = patterns or [pattern]
 
     def __iter__(self):
-        methods = self._resolve_methods()
-        for method in methods:
-            yield ViewSetMethodIntrospector(self, methods[method], method)
+        for pattern in self.patterns:
+            methods = self._resolve_methods(pattern=pattern)
+            for method in methods:
+                yield ViewSetMethodIntrospector(self, methods[method], method)
 
     def methods(self):
         stuff = []

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -285,7 +285,7 @@ class BaseMethodIntrospector(object):
         body_params = self.build_body_parameters()
         form_params = self.build_form_parameters()
         query_params = self.build_query_parameters()
-        if django_filters is not None:
+        if self.method == 'list' and django_filters is not None:
             query_params.extend(
                 self.build_query_parameters_from_django_filters())
 


### PR DESCRIPTION
Expose filter query parameters only for endpoints are behind a `list` action.