### PR TITLE
Added Functionality for sending custom headers to swagger resource APIs

### DIFF
--- a/rest_framework_swagger/static/rest_framework_swagger/lib/swagger.js
+++ b/rest_framework_swagger/static/rest_framework_swagger/lib/swagger.js
@@ -87,6 +87,7 @@ var SwaggerApi = function(url, options) {
   this.authorizations = null;
   this.authorizationScheme = null;
   this.info = null;
+  this.custom_headers = url.apiCustomHeaders
 
   options = (options||{});
   if (url)
@@ -111,14 +112,18 @@ var SwaggerApi = function(url, options) {
 
 SwaggerApi.prototype.build = function() {
   var _this = this;
+  var api_headers = {accept: "application/json"}
+
+  for (var property in this.custom_headers) {
+        api_headers[property] = this.custom_headers[property]
+  }
   this.progress('fetching resource list: ' + this.url);
+
   var obj = {
     useJQuery: this.useJQuery,
     url: this.url,
     method: "get",
-    headers: {
-      accept: "application/json"
-    },
+    headers: api_headers,
     on: {
       error: function(response) {
         if (_this.url.substring(0, 4) !== 'http') {
@@ -152,6 +157,7 @@ SwaggerApi.prototype.buildFromSpec = function(response) {
   if (response.apiVersion != null) {
     this.apiVersion = response.apiVersion;
   }
+  this.apiCustomHeaders = response.apiCustomHeaders
   this.apis = {};
   this.apisArray = [];
   this.produces = response.produces;
@@ -206,6 +212,7 @@ SwaggerApi.prototype.buildFrom1_1Spec = function(response) {
   this.apis = {};
   this.apisArray = [];
   this.produces = response.produces;
+  this.apiCustomHeaders = response.apiCustomHeaders
   if (response.info != null) {
     this.info = response.info;
   }
@@ -332,6 +339,11 @@ var SwaggerResource = function(resourceObj, api) {
   this.rawModels = {};
   this.useJQuery = (typeof api.useJQuery !== 'undefined' ? api.useJQuery : null);
 
+  var api_headers = {accept: "application/json"}
+  for (var property in this.api.custom_headers) {
+    api_headers[property] = this.api.custom_headers[property]
+  }
+
   if ((resourceObj.apis != null) && (this.api.resourcePath != null)) {
     this.addApiDeclaration(resourceObj);
   } else {
@@ -348,9 +360,7 @@ var SwaggerResource = function(resourceObj, api) {
       url: this.url,
       method: "get",
       useJQuery: this.useJQuery,
-      headers: {
-        accept: "application/json"
-      },
+      headers: api_headers,
       on: {
         response: function(resp) {
           var responseObj = resp.obj || JSON.parse(resp.data);

--- a/rest_framework_swagger/templates/rest_framework_swagger/base.html
+++ b/rest_framework_swagger/templates/rest_framework_swagger/base.html
@@ -67,6 +67,7 @@
                     url: '{{ swagger_settings.discovery_url }}',
                     apiKey: '{{ swagger_settings.api_key }}',
                     dom_id: 'swagger-ui-container',
+                    apiCustomHeaders: {{ swagger_settings.apiCustomHeaders|safe }},
                     supportedSubmitMethods: {{ swagger_settings.enabled_methods }},
                     onComplete: function (swaggerApi, swaggerUi){
                         log('Loaded SwaggerUI')

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -65,10 +65,12 @@ class SwaggerUIView(View):
                 'enabled_methods': mark_safe(
                     json.dumps(rfs.SWAGGER_SETTINGS.get('enabled_methods'))),
                 'doc_expansion': rfs.SWAGGER_SETTINGS.get('doc_expansion', ''),
+                'apiCustomHeaders': json.dumps(
+                    rfs.SWAGGER_SETTINGS.get('custom_headers', {}))
             }
         }
         response = render_to_response(
-            template_name, RequestContext(request, data))
+            template_name, data, RequestContext(request))
 
         return response
 
@@ -112,6 +114,7 @@ class SwaggerResourcesView(APIDocView):
             'apiVersion': rfs.SWAGGER_SETTINGS.get('api_version', ''),
             'swaggerVersion': '1.2',
             'basePath': self.get_base_path(),
+            'apiCustomHeaders': rfs.SWAGGER_SETTINGS.get('custom_headers', {}),
             'apis': apis,
             'info': rfs.SWAGGER_SETTINGS.get('info', {
                 'contact': '',
@@ -155,6 +158,7 @@ class SwaggerApiView(APIDocView):
             'swaggerVersion': '1.2',
             'basePath': self.api_full_uri.rstrip('/'),
             'resourcePath': '/' + path,
+            'apiCustomHeaders': rfs.SWAGGER_SETTINGS.get('custom_headers', {}),
             'apis': generator.generate(apis),
             'models': generator.get_models(apis),
         })

--- a/tests/cigar_example/cigar_example/restapi/views.py
+++ b/tests/cigar_example/cigar_example/restapi/views.py
@@ -55,15 +55,6 @@ class ArtisanCigarViewSet(viewsets.ModelViewSet):
     """
     Cigar resource.
     ---
-    get_price:
-        omit_serializer: true
-    set_price:
-        omit_serializer: true
-        parameters_strategy:
-            form: replace
-        parameters:
-            - name: price
-              type: number
     """
 
     serializer_class = CigarSerializer

--- a/tests/cigar_example/cigar_example/settings.py
+++ b/tests/cigar_example/cigar_example/settings.py
@@ -170,9 +170,11 @@ LOGGING = {
     }
 }
 
+API_VERSION = "0.1.10"
+
 SWAGGER_SETTINGS = {
     "exclude_namespaces": [],    # List URL namespaces to ignore
-    "api_version": '0.1.10',  # Specify your API's version (optional)
+    "api_version": API_VERSION,  # Specify your API's version (optional)
     "token_type": 'Bearer',
     "enabled_methods": [  # Methods to enable in UI
         'get',
@@ -181,6 +183,7 @@ SWAGGER_SETTINGS = {
         'patch',
         'delete'
     ],
-    "is_authenticated": False
+    "is_authenticated": False,
+    "custom_headers": {"X-API-VERSION": API_VERSION}
 }
 APPEND_SLASH = False


### PR DESCRIPTION
Settings changes - 
"custom_headers": {"X-API-VERSION": "Version 1.1.0"}

It will send a custom header to API like HTTP_X_API_VERSION which is helpful in defining API versions.

 