### PR TITLE
Add PyYAML to requirements list

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ for more information, see the [documentation][docs].
 * Python (2.6.5+, 2.7, 3.2, 3.3, 3.4)
 * Django (1.5.5+, 1.6, 1.7, 1.8)
 * Django REST framework (2.3.8+)
+* PyYAML (3.10+)
 
 ## Bugs & Contributions
 Please report bugs by opening an issue


### PR DESCRIPTION
Django REST swagger cannot be run without PyYAML. Since PyYAML is not a depedency of django or django-rest-framework it has to be stated here. It is listed in setup.py though.