### PR TITLE
Update docgenerator.py

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -338,10 +338,10 @@ class DocumentationGenerator(object):
                     has_many = isinstance(field, ListSerializer)
                 if has_many:
                     f['type'] = 'array'
-                    if data_type in BaseMethodIntrospector.PRIMITIVES:
-                        f['items'] = {'type': data_type}
-                    else:
+                    if field_serializer:
                         f['items'] = {'$ref': field_serializer}
+                    elif data_type in BaseMethodIntrospector.PRIMITIVES:
+                        f['items'] = {'type': data_type}
 
             # memorize discovered field
             data['fields'][name] = f

--- a/rest_framework_swagger/templates/rest_framework_swagger/base.html
+++ b/rest_framework_swagger/templates/rest_framework_swagger/base.html
@@ -13,8 +13,8 @@
             <link href="{% static 'rest_framework_swagger/css/screen.css' %}" media="screen" rel="stylesheet" type="text/css"/>
         {% endblock %}
     </head>
-
     <body>
+        {% block body %}
         {% block header %}
             <div id="header">
                 <div class="swagger-ui-wrap">
@@ -95,6 +95,7 @@
                 window.swaggerUi.load();
             });
         </script>
+        {% endblock %}
     </body>
 </html>
 {% endspaceless %}


### PR DESCRIPTION
We might need to give priority to field_serializer refs.

In many cases data type will result in 'string' in BaseMethodIntrospector.PRIMITIVES

And never fall into the else.

I may be doing something wrong with the setup of serializer classes but here is what I have:

```
class DictField(serializers.DictField):
    @property
    def type_label(self):
        return "dict"


class DictSerializer(serializers.Serializer):
    row = DictField()

    class Meta:
        fields = ('row',)


class PaginationSerializer(serializers.Serializer):
    count = serializers.IntegerField()
    next = serializers.URLField()
    previous = serializers.URLField()
    results = DictSerializer(many=True)

    class Meta:
        fields = ('count', 'next', 'previous', 'results')
```