### PR TITLE
A less naive strategy for getting view closure var

### DIFF
--- a/rest_framework_swagger/decorators.py
+++ b/rest_framework_swagger/decorators.py
@@ -35,10 +35,16 @@ def closure_n_code(func):
 
 def get_closure_var(func, name=None):
     unwrap = closure_n_code(func)
-    i = 0
     if name:
-        i = unwrap.code.co_freevars.index(name)
-    return unwrap.closure[i].cell_contents
+        index = unwrap.code.co_freevars.index(name)
+        return unwrap.closure[index].cell_contents
+    else:
+        for closure_var in unwrap.closure:
+            if isinstance(closure_var.cell_contents, types.FunctionType):
+                return closure_var.cell_contents
+        else:
+            return None
+
 
 def wrapper_to_func(wrapper):
     noms = wrapper.http_method_names

--- a/rest_framework_swagger/decorators.py
+++ b/rest_framework_swagger/decorators.py
@@ -40,7 +40,6 @@ def get_closure_var(func, name=None):
         i = unwrap.code.co_freevars.index(name)
     return unwrap.closure[i].cell_contents
 
-
 def wrapper_to_func(wrapper):
     noms = wrapper.http_method_names
     handlers = [getattr(wrapper, m) for m in noms if m != 'options']


### PR DESCRIPTION
 - Handles a particular class of decorated view functions that refer to the outermost closure arguments.
 - Searches for a types.FunctionType argument in the closure, rather than assuming the first
   argument is the view. This is a correct implementation for existing cases as well.