### PR TITLE
Omit empty resources

### DIFF
--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -100,14 +100,7 @@ class SwaggerResourcesView(APIDocView):
     renderer_classes = (JSONRenderer, )
 
     def get(self, request):
-        apis = []
-
-        resources = [resource for resource in self.get_resources()
-                     if self.handle_resource_access(request, resource)]
-
-        for path in resources:
-            apis.append({'path': '/%s' % path, })
-
+        apis = [{'path': '/' + path} for path in self.get_resources()]
         return Response({
             'apiVersion': rfs.SWAGGER_SETTINGS.get('api_version', ''),
             'swaggerVersion': '1.2',
@@ -136,11 +129,10 @@ class SwaggerResourcesView(APIDocView):
     def get_resources(self):
         urlparser = UrlParser()
         urlconf = getattr(self.request, "urlconf", None)
-        apis = urlparser.get_apis(
-            urlconf=urlconf,
-            exclude_namespaces=rfs.SWAGGER_SETTINGS.get('exclude_namespaces')
-        )
-        resources = urlparser.get_top_level_apis(apis)
+        exclude_namespaces = rfs.SWAGGER_SETTINGS.get('exclude_namespaces')
+        apis = urlparser.get_apis(urlconf=urlconf, exclude_namespaces=exclude_namespaces)
+        authorized_apis = filter(lambda a: self.handle_resource_access(self.request, a['pattern']), apis)
+        resources = urlparser.get_top_level_apis(authorized_apis)
         return resources
 
 

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -132,7 +132,8 @@ class SwaggerResourcesView(APIDocView):
         exclude_namespaces = rfs.SWAGGER_SETTINGS.get('exclude_namespaces')
         apis = urlparser.get_apis(urlconf=urlconf, exclude_namespaces=exclude_namespaces)
         authorized_apis = filter(lambda a: self.handle_resource_access(self.request, a['pattern']), apis)
-        resources = urlparser.get_top_level_apis(authorized_apis)
+        authorized_apis_list = list(authorized_apis)
+        resources = urlparser.get_top_level_apis(authorized_apis_list)
         return resources
 
 
@@ -156,4 +157,5 @@ class SwaggerApiView(APIDocView):
         urlconf = getattr(self.request, "urlconf", None)
         apis = urlparser.get_apis(urlconf=urlconf, filter_path=filter_path)
         authorized_apis = filter(lambda a: self.handle_resource_access(self.request, a['pattern']), apis)
-        return authorized_apis
+        authorized_apis_list = list(authorized_apis)
+        return authorized_apis_list

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -97,7 +97,7 @@ class SwaggerUIView(View):
 
 
 class SwaggerResourcesView(APIDocView):
-    renderer_classes = (JSONRenderer,)
+    renderer_classes = (JSONRenderer, )
 
     def get(self, request):
         apis = []

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps =
     py26: Markdown==2.1.1
     py26: importlib==1.0.1
     py26: ordereddict==1.1
+    py27: functools32==3.2.3-2
     docutils==0.11
     argparse==1.2.1
     argh==0.23.2


### PR DESCRIPTION
I've amended the code for handling resource access because I've found a bug that is exercised by one of my use cases. If all of the APIs provided by a Resource are excluded by `handle_resource_access`, and that resource is actually just a label to collect a bunch of similar APIs together, then that Resource will show up. This is problematic because:
 - It's generally messy looking
 - It's sort of confusing and looks broken that the top level resources aren't expanding when clicked
 - It may expose details of your business that you would otherwise prefer to keep private

The problem is solved simply by doing the check at an earlier stage of processing.