### PR TITLE
Get serializer by request user

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -20,6 +20,9 @@ class DocumentationGenerator(object):
     # Response classes defined in docstrings
     explicit_response_types = dict()
 
+    def __init__(self, for_user):
+        self.user = for_user
+
     def generate(self, apis):
         """
         Returns documentation for a list of APIs
@@ -39,14 +42,13 @@ class DocumentationGenerator(object):
         pattern = api['pattern']
         callback = api['callback']
         if callback.__module__ == 'rest_framework.decorators':
-            return WrappedAPIViewIntrospector(callback, path, pattern)
+            return WrappedAPIViewIntrospector(callback, path, pattern, self.user)
         elif issubclass(callback, viewsets.ViewSetMixin):
             patterns = [a['pattern'] for a in apis
                         if a['callback'] == callback]
-            return ViewSetIntrospector(callback, path, pattern,
-                                       patterns=patterns)
+            return ViewSetIntrospector(callback, path, pattern, self.user, patterns=patterns)
         else:
-            return APIViewIntrospector(callback, path, pattern)
+            return APIViewIntrospector(callback, path, pattern, self.user)
 
     def get_operations(self, api, apis=None):
         """

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -1,4 +1,5 @@
 """Generates API documentation by introspection."""
+from django.contrib.auth.models import AnonymousUser
 import rest_framework
 from rest_framework import viewsets
 from rest_framework.serializers import BaseSerializer
@@ -25,8 +26,8 @@ class DocumentationGenerator(object):
     # Response classes defined in docstrings
     explicit_response_types = dict()
 
-    def __init__(self, for_user):
-        self.user = for_user
+    def __init__(self, for_user=None):
+        self.user = for_user or AnonymousUser()
 
     def generate(self, apis):
         """

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -3,10 +3,15 @@ import rest_framework
 from rest_framework import viewsets
 from rest_framework.serializers import BaseSerializer
 
-from .introspectors import APIViewIntrospector, \
-    WrappedAPIViewIntrospector, \
-    ViewSetIntrospector, BaseMethodIntrospector, IntrospectorHelper, \
-    get_default_value, get_data_type
+from .introspectors import (
+    APIViewIntrospector,
+    BaseMethodIntrospector,
+    IntrospectorHelper,
+    ViewSetIntrospector,
+    WrappedAPIViewIntrospector,
+    get_data_type,
+    get_default_value,
+)
 from .compat import OrderedDict
 
 

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -153,7 +153,7 @@ class SwaggerApiView(APIDocView):
         apis = [api for api in apis
                 if self.handle_resource_access(request, api['pattern'])]
 
-        generator = DocumentationGenerator()
+        generator = DocumentationGenerator(for_user=request.user)
 
         return Response({
             'apiVersion': rfs.SWAGGER_SETTINGS.get('api_version', ''),


### PR DESCRIPTION
- Uses the Django request user to determine which serializer to document during introspection.
- Expands on the concept introduced by `resource_access_callback`, with the goal of allowing the developer to provide a single documentation view that is contextually-sane for the whomever is making the request.
- Includes test coverage to exercise user-specific behaviour.