### PR TITLE
Adds jsonschema requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ argparse==1.2.1
 coverage==3.6
 django-nose==1.2
 djangorestframework>=2.3.8
+jsonschema==2.5
 nose==1.3.0
 mock==1.0.1
 ordereddict==1.1


### PR DESCRIPTION
Seems you added it to tox.ini but missed it in the requirements.txt here:

https://github.com/marcgibbons/django-rest-swagger/blob/0edbf36992ec8e9c8ad54d5a1f92fdeddf3f619b/tox.ini#L31