### PR TITLE
Fix enum output regression for choice fields

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -328,7 +328,7 @@ class DocumentationGenerator(object):
                 f['maximum'] = max_val
 
             # ENUM options
-            if get_data_type(field) in ['multiple choice', 'choice']:
+            if data_type in BaseMethodIntrospector.ENUMS:
                 if isinstance(field.choices, list):
                     f['enum'] = [k for k, v in field.choices]
                 elif isinstance(field.choices, dict):

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -154,6 +154,11 @@ class BaseViewIntrospector(object):
 class BaseMethodIntrospector(object):
     __metaclass__ = ABCMeta
 
+    ENUMS = [
+        'choice',
+        'multiple choice',
+    ]
+
     PRIMITIVES = {
         'integer': ['int32', 'int64'],
         'number': ['float', 'double'],
@@ -449,7 +454,7 @@ class BaseMethodIntrospector(object):
                 f['maximum'] = max_val
 
             # ENUM options
-            if get_data_type(field)[0] in ['multiple choice', 'choice']:
+            if data_type in BaseMethodIntrospector.ENUMS:
                 if isinstance(field.choices, list):
                     f['enum'] = [k for k, v in field.choices]
                 elif isinstance(field.choices, dict):

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -1302,6 +1302,7 @@ class BaseMethodIntrospectorTest(TestCase, DocumentationGeneratorMixin):
         self.assertIn(
             properties["choice"]["type"],
             ["choice", "multiple choice"])
+        self.assertIn("enum", properties["choice"].keys())
         self.assertEqual("string", properties["regex"]["type"])
         self.assertEqual("number", properties["float"]["type"])
         self.assertEqual("float", properties["float"]["format"])


### PR DESCRIPTION
A recently merged branch introduced a regression that broke the enumerations for choice fields. This resolves that an adds test coverage to ensure it doesn't regress again.