### PR TITLE
Handle ManyRelatedField type as an array of strings

### DIFF
--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -1093,6 +1093,13 @@ MY_CHOICES = (
 )
 
 
+class KitchenSinkRelatedField(serializers.RelatedField):
+    read_only = False
+
+    def to_representation(self, obj):
+        return unicode(obj)
+
+
 class KitchenSinkSerializer(serializers.Serializer):
     email = serializers.EmailField()
     content = serializers.CharField(max_length=200)
@@ -1111,6 +1118,8 @@ class KitchenSinkSerializer(serializers.Serializer):
     file = serializers.FileField()
     image = serializers.ImageField()
     joop = serializers.PrimaryKeyRelatedField(queryset=1)
+    many_related = KitchenSinkRelatedField(many=True, queryset=1)
+    single_related = KitchenSinkRelatedField(queryset=1)
 
 
 class BaseMethodIntrospectorTest(TestCase, DocumentationGeneratorMixin):
@@ -1309,6 +1318,9 @@ class BaseMethodIntrospectorTest(TestCase, DocumentationGeneratorMixin):
         self.assertEqual("string", properties["file"]["type"])
         self.assertEqual("string", properties["image"]["type"])
         self.assertEqual("string", properties["joop"]["type"])
+        self.assertEqual("array", properties["many_related"]["type"])
+        self.assertEqual("string", properties["many_related"]["items"]["type"])
+        self.assertEqual("string", properties["single_related"]["type"])
 
     def test_build_form_parameters_allowable_values(self):
 


### PR DESCRIPTION
Instead of treating `ManyRelatedField` as a string type, it seems more reasonable to treat is as an array of strings. `RelatedField` and it's subclasses without the `many=True` argument will still fall under the assumption of string as was the case before.

Added test coverage for the use case.