### PR TITLE
Fix attribute name on field for minimum/maximum

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -319,13 +319,13 @@ class DocumentationGenerator(object):
                 del f['defaultValue']
 
             # Min/Max values
-            max_val = getattr(field, 'max_val', None)
-            min_val = getattr(field, 'min_val', None)
-            if max_val is not None and data_type == 'integer':
-                f['minimum'] = min_val
+            max_value = getattr(field, 'max_value', None)
+            min_value = getattr(field, 'min_value', None)
+            if max_value is not None and data_type == 'integer':
+                f['minimum'] = min_value
 
-            if max_val is not None and data_type == 'integer':
-                f['maximum'] = max_val
+            if max_value is not None and data_type == 'integer':
+                f['maximum'] = max_value
 
             # ENUM options
             if get_data_type(field) in ['multiple choice', 'choice']:

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -440,13 +440,13 @@ class BaseMethodIntrospector(object):
                 del f['defaultValue']
 
             # Min/Max values
-            max_val = getattr(field, 'max_val', None)
-            min_val = getattr(field, 'min_val', None)
-            if max_val is not None and data_type == 'integer':
-                f['minimum'] = min_val
+            max_value = getattr(field, 'max_value', None)
+            min_value = getattr(field, 'min_value', None)
+            if max_value is not None and data_type == 'integer':
+                f['minimum'] = min_value
 
-            if max_val is not None and data_type == 'integer':
-                f['maximum'] = max_val
+            if max_value is not None and data_type == 'integer':
+                f['maximum'] = max_value
 
             # ENUM options
             if get_data_type(field)[0] in ['multiple choice', 'choice']:


### PR DESCRIPTION
Looked at old versions of DRF and it was apparently always `min_value` and `max_value`.