### PR TITLE
Weird body margin fix

### DIFF
--- a/rest_framework_swagger/static/rest_framework_swagger/css/rest_framework_swagger.css
+++ b/rest_framework_swagger/static/rest_framework_swagger/css/rest_framework_swagger.css
@@ -1,3 +1,7 @@
+body {
+    margin: 0px;
+}
+
 #django-rest-swagger {
     background: #547f00; 
     color: #eee; 


### PR DESCRIPTION
Something is adding 8px of margin on the body and made the page look like bad.  Didn't feel like digging in to find the source but this override fixes it.