### PR TITLE
Update base.html

### DIFF
--- a/rest_framework_swagger/templates/rest_framework_swagger/base.html
+++ b/rest_framework_swagger/templates/rest_framework_swagger/base.html
@@ -47,7 +47,7 @@
         <div id="swagger-ui-container" class="swagger-ui-wrap"></div>
 
         <script>
-            window.static_url = '{{STATIC_URL}}';
+            window.static_url = "{% static '' %}";
         </script>
         <script src="{% static 'rest_framework_swagger/lib/shred.bundle.js' %}" type="text/javascript"></script>
         <script src="{% static 'rest_framework_swagger/lib/jquery-1.8.0.min.js' %}" type="text/javascript"></script>


### PR DESCRIPTION
404 error on loading throbber.gif 
"GET /docs/rest_framework_swagger/images/throbber.gif HTTP/1.1" 404 

Fixed window.static_url (for JS to load static resources correctly).