### PR TITLE
Fix for Assertion errors introduced in 3.0.2

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -177,7 +177,6 @@ class DocumentationGenerator(object):
 
         Serializer might be ignored if explicitly told in docstring
         """
-        serializer = method_inspector.get_response_serializer_class()
         doc_parser = method_inspector.get_yaml_parser()
 
         if doc_parser.get_response_type() is not None:
@@ -185,8 +184,9 @@ class DocumentationGenerator(object):
             return None
 
         if doc_parser.should_omit_serializer():
-            serializer = None
+            return None
 
+        serializer = method_inspector.get_response_serializer_class()
         return serializer
 
     def _get_method_response_type(self, doc_parser, serializer,

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -217,7 +217,14 @@ class BaseMethodIntrospector(object):
             if view is not None:
                 if parser.should_omit_serializer():
                     return None
-                return view.get_serializer_class()
+                try:
+                    serializer_class = view.get_serializer_class()
+                except AssertionError as e:
+                    if "should either include a `serializer_class` attribute, or override the `get_serializer_class()` method." in str(e):  # noqa
+                        serializer_class = None
+                    else:
+                        raise
+                return serializer_class
 
     def create_view(self):
         view = self.callback()

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -215,6 +215,8 @@ class BaseMethodIntrospector(object):
             mock_view = parser.get_view_mocker(self.callback)
             view = mock_view(view)
             if view is not None:
+                if parser.should_omit_serializer():
+                    return None
                 return view.get_serializer_class()
 
     def create_view(self):


### PR DESCRIPTION
probably needs testing, but it now works for me.

Noticed a few quirks in docgenerator having no docstring (self.object ) when requesting serializers for views where I know a docstring is present... The try/Except seems to mitigate this.