### PR TITLE
Allow user to configure AnonymousUser class

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -21,6 +21,7 @@ Example:
         'api_key': '',
         'is_authenticated': False,
         'is_superuser': False,
+        'unauthenticated_user': 'django.contrib.auth.models.AnonymousUser',
         'permission_denied_handler': None,
         'resource_access_handler': None,
         'base_path':'helloreverb.com/docs',
@@ -110,6 +111,15 @@ is_superuser
 set to True to enforce admin only access
 
 Default: :code:`False`
+
+unauthenticated_user
+-------------------------
+
+Sets the class that is used for the user in unauthenticated requests.
+
+set to None to specify no user class
+
+Default: :code:`django.contrib.auth.models.AnonymousUser`
 
 permission_denied_handler
 -------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ argparse==1.2.1
 coverage==3.6
 django-nose==1.2
 djangorestframework>=2.3.8
+django-filter==0.11.0
 jsonschema==2.5
 nose==1.3.0
 mock==1.0.1

--- a/rest_framework_swagger/__init__.py
+++ b/rest_framework_swagger/__init__.py
@@ -9,6 +9,7 @@ DEFAULT_SWAGGER_SETTINGS = {
     'enabled_methods': ['get', 'post', 'put', 'patch', 'delete'],
     'is_authenticated': False,
     'is_superuser': False,
+    'unauthenticated_user': 'django.contrib.auth.models.AnonymousUser',
     'permission_denied_handler': None,
     'resource_access_handler': None,
     'template_path': 'rest_framework_swagger/index.html',


### PR DESCRIPTION
While using Django 1.7 or 1.8, the following warning is displayed when importing ```django_rest_swagger```:

```
/usr/local/lib/python2.7/site-packages/django/contrib/contenttypes/models.py:159: RemovedInDjango19Warning: Model class django.contrib.contenttypes.models.ContentType doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class ContentType(models.Model):

/usr/local/lib/python2.7/site-packages/django/contrib/auth/models.py:41: RemovedInDjango19Warning: Model class django.contrib.auth.models.Permission doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Permission(models.Model):

/usr/local/lib/python2.7/site-packages/django/contrib/auth/models.py:98: RemovedInDjango19Warning: Model class django.contrib.auth.models.Group doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Group(models.Model):

/usr/local/lib/python2.7/site-packages/django/contrib/auth/models.py:436: RemovedInDjango19Warning: Model class django.contrib.auth.models.User doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class User(AbstractUser):
```

This occurs when ```django.contrib.contenttypes``` and ```django.contrib.auth``` are not included in ```INSTALLED_APPS```.  Starting in Django 1.9, the user will be required to list these apps (which has the unpleasant side-effect of inserting additional tables into the database migrations), even if they do not use them explicitly.

This is due to the explicit import of ```django.contrib.auth.models.AnonymousUser``` in ```docgenerator.py```.

This pull request addresses the issue by adding a ```unauthenticated_user``` setting which defaults to ```django.contrib.auth.models.AnonymousUser``` but allows the end user to override this to ```None``` or some other class.  This class is then imported with ```import_lib``` so that the user is not forced to install the aforementioned apps.  This new setting is similar to the ```UNAUTHENTICATED_USER``` setting provided for ```django-rest-framework```.