### PR TITLE
Ensuring fields.ListField introspects as 'array' #367

### DIFF
--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -520,8 +520,13 @@ def get_data_type(field):
         # return 'string', 'string' # 'file upload'
     # elif isinstance(field, fields.CharField):
         # return 'string', 'string'
-    elif rest_framework.VERSION >= '3.0.0' and isinstance(field, fields.HiddenField):
-        return 'hidden', 'hidden'
+    elif rest_framework.VERSION >= '3.0.0':
+        if isinstance(field, fields.HiddenField):
+            return 'hidden', 'hidden'
+        elif isinstance(field, fields.ListField):
+            return 'array', 'array'
+        else:
+            return 'string', 'string'
     else:
         return 'string', 'string'
 

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -1179,6 +1179,7 @@ class KitchenSinkSerializer(serializers.Serializer):
     expires_by = serializers.TimeField()
     age = serializers.IntegerField()
     flagged = serializers.BooleanField()
+    array = serializers.ListField()
     url = serializers.URLField()
     slug = serializers.SlugField()
     choice = serializers.ChoiceField(
@@ -1376,6 +1377,7 @@ class BaseMethodIntrospectorTest(TestCase, DocumentationGeneratorMixin):
         self.assertEqual("string", properties["expires_by"]["type"])
         self.assertEqual("integer", properties["age"]["type"])
         self.assertEqual("boolean", properties["flagged"]["type"])
+        self.assertEqual("array", properties["array"]["type"])
         self.assertEqual("string", properties["url"]["type"])
         self.assertNotIn("format", properties["url"])
         self.assertEqual("string", properties["slug"]["type"])

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -38,7 +38,7 @@ from .urlparser import UrlParser
 from .docgenerator import DocumentationGenerator
 from .introspectors import ViewSetIntrospector, APIViewIntrospector, \
     WrappedAPIViewMethodIntrospector, IntrospectorHelper, \
-    APIViewMethodIntrospector
+    APIViewMethodIntrospector, get_data_type
 from . import DEFAULT_SWAGGER_SETTINGS
 
 
@@ -542,6 +542,16 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
         self.assertEqual(
             ["email", "content", "created"],
             list(models['CommentSerializer']['properties'].keys()))
+
+    def test_listfield_drf3(self):
+        if StrictVersion(rest_framework.VERSION) < StrictVersion('3.0'):
+            raise SkipTest('Only for DRF>=3.0')
+
+        from rest_framework.fields import ListField
+
+        list_field_data_type = get_data_type(ListField())
+
+        self.assertEqual(("array", "array"), list_field_data_type)
 
     def test_get_models_ordering_drf3(self):
         if StrictVersion(rest_framework.VERSION) < StrictVersion('3.0'):
@@ -1179,7 +1189,6 @@ class KitchenSinkSerializer(serializers.Serializer):
     expires_by = serializers.TimeField()
     age = serializers.IntegerField()
     flagged = serializers.BooleanField()
-    array = serializers.ListField()
     url = serializers.URLField()
     slug = serializers.SlugField()
     choice = serializers.ChoiceField(
@@ -1377,7 +1386,6 @@ class BaseMethodIntrospectorTest(TestCase, DocumentationGeneratorMixin):
         self.assertEqual("string", properties["expires_by"]["type"])
         self.assertEqual("integer", properties["age"]["type"])
         self.assertEqual("boolean", properties["flagged"]["type"])
-        self.assertEqual("array", properties["array"]["type"])
         self.assertEqual("string", properties["url"]["type"])
         self.assertNotIn("format", properties["url"])
         self.assertEqual("string", properties["slug"]["type"])


### PR DESCRIPTION
Adding introspection for `rest_framework.fields.ListField` ([a new serializer field in rest_framework 3.0](http://www.django-rest-framework.org/topics/3.0-announcement/)) so its type is `array` as opposed to `string`. This pull request includes test coverage.