### PR TITLE
Allow is_staff setting to make Api documentation available for staff only

### DIFF
--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -76,7 +76,11 @@ class SwaggerUIView(View):
         if rfs.SWAGGER_SETTINGS.get('is_superuser') and \
                 not request.user.is_superuser:
             return False
-
+        
+        if rfs.SWAGGER_SETTINGS.get('is_staff') and \
+                not request.user.is_staff:
+            return False
+            
         if rfs.SWAGGER_SETTINGS.get('is_authenticated') and \
                 not request.user.is_authenticated():
             return False


### PR DESCRIPTION
is_staff setting for allowing to see documentation for staff users only.