### PR TITLE
Handle DRF's AcceptHeaderVersioning: send version in Accept header

### DIFF
--- a/rest_framework_swagger/templates/rest_framework_swagger/base.html
+++ b/rest_framework_swagger/templates/rest_framework_swagger/base.html
@@ -92,6 +92,23 @@
                     window.authorizations.add('key', new ApiKeyAuthorization('Authorization', '{{ swagger_settings.token_type }} ' + '{{ swagger_settings.api_key }}', 'header'));
                 {% endif %}
 
+                {# Add version to Accept header, if AcceptHeaderVersioning is used. #}
+                {% if swagger_settings.api_version and rest_framework_settings.DEFAULT_VERSIONING_CLASS == 'rest_framework.versioning.AcceptHeaderVersioning' %}
+                    window.authorizations.add('version', {
+                        apply: function(obj, authorizations) {
+                            $.each(obj.headers, function(k, v) {
+                                if (k.toLowerCase() === "accept") {
+                                    if (v.indexOf('; version=') === -1) {
+                                        obj.headers[k] += "; version={{ swagger_settings.api_version }}";
+                                    }
+                                    return false;  // break.
+                                }
+                            });
+                            return true;
+                        }
+                    });
+                {% endif %}
+
                 window.swaggerUi.load();
             });
         </script>

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -1,6 +1,7 @@
 import json
 from django.utils import six
 
+from django.conf import settings
 from django.views.generic import View
 from django.utils.safestring import mark_safe
 from django.utils.encoding import smart_text
@@ -61,10 +62,17 @@ class SwaggerUIView(View):
             'swagger_settings': {
                 'discovery_url': "%s/api-docs/" % get_full_base_path(request),
                 'api_key': rfs.SWAGGER_SETTINGS.get('api_key', ''),
+                'api_version': rfs.SWAGGER_SETTINGS.get('api_version', ''),
                 'token_type': rfs.SWAGGER_SETTINGS.get('token_type'),
                 'enabled_methods': mark_safe(
                     json.dumps(rfs.SWAGGER_SETTINGS.get('enabled_methods'))),
                 'doc_expansion': rfs.SWAGGER_SETTINGS.get('doc_expansion', ''),
+            },
+            'rest_framework_settings': {
+                'DEFAULT_VERSIONING_CLASS':
+                    settings.REST_FRAMEWORK.get('DEFAULT_VERSIONING_CLASS', '')
+                    if hasattr(settings, 'REST_FRAMEWORK') else None,
+
             }
         }
         response = render_to_response(


### PR DESCRIPTION
Add an authorizations handler to append the version from
`swagger_settings.api_version`.

This is required to make Swagger work with an API that uses
AcceptHeaderVersioning, where you would get an error for the missing
version header otherwise.