### PR TITLE
Use the new style urlpatterns syntax to fix Django deprecation warnings

### DIFF
--- a/rest_framework_swagger/urls.py
+++ b/rest_framework_swagger/urls.py
@@ -1,11 +1,9 @@
-from django.conf.urls import patterns
 from django.conf.urls import url
 from rest_framework_swagger.views import SwaggerResourcesView, SwaggerApiView, SwaggerUIView
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', SwaggerUIView.as_view(), name="django.swagger.base.view"),
     url(r'^api-docs/$', SwaggerResourcesView.as_view(), name="django.swagger.resources.view"),
     url(r'^api-docs/(?P<path>.*)/?$', SwaggerApiView.as_view(), name='django.swagger.api.view'),
-)
+]


### PR DESCRIPTION
The `patterns()` syntax is now deprecated:
https://docs.djangoproject.com/en/1.8/releases/1.8/#django-conf-urls-patterns

And so under Django 1.8 results in warnings:
> rest_framework_swagger/urls.py:10: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.

Fixes #380.