### PR TITLE
Fix display of Array fields

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -357,8 +357,8 @@ class DocumentationGenerator(object):
             if rest_framework.VERSION < '3.0.0':
                 has_many = hasattr(field, 'many') and field.many
             else:
-                from rest_framework.serializers import ListSerializer, ManyRelatedField
-                has_many = isinstance(field, (ListSerializer, ManyRelatedField))
+                from rest_framework.serializers import ListField, ManyRelatedField
+                has_many = isinstance(field, (ListField, ManyRelatedField))
 
             if isinstance(field, BaseSerializer) or has_many:
                 if isinstance(field, BaseSerializer):

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -638,7 +638,20 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
         fields = docgen._get_serializer_fields(OtherSerializer)
 
         self.assertEqual(1, len(fields['fields']))
+        self.assertEqual("SomeSerializer", fields['fields']['thing2']['type'])
+
+    def test_get_serializer_fields_api_with_list_field(self):
+        class SomeSerializer(serializers.Serializer):
+            thing1 = serializers.ListField(
+                child=serializers.CharField()
+            )
+
+        docgen = self.get_documentation_generator()
+        fields = docgen._get_serializer_fields(SomeSerializer)
+
+        self.assertEqual(1, len(fields['fields']))
         self.assertEqual("array", fields['fields']['thing2']['type'])
+        self.assertEqual("string", fields['fields']['thing2']['items']['type'])
 
     def test_nested_serializer(self):
         class ASerializer(serializers.Serializer):

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -650,8 +650,8 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
         fields = docgen._get_serializer_fields(SomeSerializer)
 
         self.assertEqual(1, len(fields['fields']))
-        self.assertEqual("array", fields['fields']['thing2']['type'])
-        self.assertEqual("string", fields['fields']['thing2']['items']['type'])
+        self.assertEqual("array", fields['fields']['thing1']['type'])
+        self.assertEqual("string", fields['fields']['thing1']['items']['type'])
 
     def test_nested_serializer(self):
         class ASerializer(serializers.Serializer):


### PR DESCRIPTION
Currently the Array-type fields do not correctly show their child type. this is because the `isInstance()` line was improperly comparing against `ListSerializer` and not `ListField`. This change fixes that.

How it looks currently:
![screen shot 2016-02-26 at 3 59 14 pm](https://cloud.githubusercontent.com/assets/521927/13368813/bcdf4cec-dca2-11e5-8b33-849911f82a9b.png)

How it looks after applying the fix:
![screen shot 2016-02-26 at 4 02 48 pm](https://cloud.githubusercontent.com/assets/521927/13368812/bcd04a08-dca2-11e5-84f8-1f07bfd08c76.png)