### PR TITLE
Use guaranteed-idempotent STATIC_URL variable

### DIFF
--- a/rest_framework_swagger/__init__.py
+++ b/rest_framework_swagger/__init__.py
@@ -1,4 +1,4 @@
-VERSION = '0.3.5'
+VERSION = '0.3.6'
 
 DEFAULT_SWAGGER_SETTINGS = {
     'exclude_namespaces': [],

--- a/rest_framework_swagger/templates/rest_framework_swagger/base.html
+++ b/rest_framework_swagger/templates/rest_framework_swagger/base.html
@@ -47,7 +47,7 @@
         <div id="swagger-ui-container" class="swagger-ui-wrap"></div>
 
         <script>
-            window.static_url = "{% static '' %}";
+            window.static_url = "{{ STATIC_URL }}";
         </script>
         <script src="{% static 'rest_framework_swagger/lib/shred.bundle.js' %}" type="text/javascript"></script>
         <script src="{% static 'rest_framework_swagger/lib/jquery-1.8.0.min.js' %}" type="text/javascript"></script>


### PR DESCRIPTION
base.html sets the window.static_url JS variable. It used to
use {% static '' %}, but that function is not idempotent in
apache libcloud.

Use the safer STATIC_URL variable, which always contains the root
of the static file tree.

This was required for me to use Django Rest Swagger with Google Cloud Storage under Django-Storages, since in that library {% static %} is not idempotent.

Since the only use of `window.static_url` is in https://github.com/marcgibbons/django-rest-swagger/blob/516c5021da9b1cceb791ce4eeb8ff3d4b6dd7d09/rest_framework_swagger/static/rest_framework_swagger/swagger-ui.js#L397, seems like the dynamic logic in `{% static '' %}` is not required.

Happy to clean up this PR if you want to merge it.