### PR TITLE
add exclude_url_name for the option to ignore particular views

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Many thanks to Tom Christie & all the contributors who have developed [Django RE
 
 [build-status-badge]: https://travis-ci.org/marcgibbons/django-rest-swagger.svg?branch=master
 [build-status]: https://travis-ci.org/marcgibbons/django-rest-swagger
-[pypi-version]: https://pypip.in/version/django-rest-swagger/badge.svg
+[pypi-version]: https://img.shields.io/pypi/v/django-rest-swagger.svg
 [pypi]: https://pypi.python.org/pypi/django-rest-swagger
 [license-badge]: https://img.shields.io/pypi/l/django-rest-swagger.svg
 [license]: https://pypi.python.org/pypi/django-rest-swagger/

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -8,6 +8,7 @@ Example:
 .. code-block:: python
 
     SWAGGER_SETTINGS = {
+        'exclude_url_names': [],
         'exclude_namespaces': [],
         'api_version': '0.1',
         'api_path': '/',
@@ -84,6 +85,13 @@ enabled_methods
 The methods that can be interacted with in the UI
 
 Default: :code:`['get', 'post', 'put', 'patch', 'delete']`
+
+exclude_url_names
+------------------------
+
+list URL names to ignore
+
+Default: :code:`[]`
 
 exclude_namespaces
 ------------------------

--- a/rest_framework_swagger/__init__.py
+++ b/rest_framework_swagger/__init__.py
@@ -1,6 +1,7 @@
 VERSION = '0.3.5'
 
 DEFAULT_SWAGGER_SETTINGS = {
+    'exclude_url_names': [],
     'exclude_namespaces': [],
     'api_version': '',
     'api_path': '/',

--- a/rest_framework_swagger/urlparser.py
+++ b/rest_framework_swagger/urlparser.py
@@ -14,11 +14,12 @@ from .apidocview import APIDocView
 
 class UrlParser(object):
 
-    def get_apis(self, patterns=None, urlconf=None, filter_path=None, exclude_namespaces=[]):
+    def get_apis(self, patterns=None, urlconf=None, filter_path=None, exclude_url_names=[], exclude_namespaces=[]):
         """
         Returns all the DRF APIViews found in the project URLs
 
         patterns -- supply list of patterns (optional)
+        exclude_url_names -- list of url names to ignore (optional)
         exclude_namespaces -- list of namespaces to ignore (optional)
         """
         if patterns is None and urlconf is not None:
@@ -34,6 +35,7 @@ class UrlParser(object):
         apis = self.__flatten_patterns_tree__(
             patterns,
             filter_path=filter_path,
+            exclude_url_names=exclude_url_names,
             exclude_namespaces=exclude_namespaces,
         )
         if filter_path is not None:
@@ -123,7 +125,7 @@ class UrlParser(object):
             'callback': callback,
         }
 
-    def __flatten_patterns_tree__(self, patterns, prefix='', filter_path=None, exclude_namespaces=[]):
+    def __flatten_patterns_tree__(self, patterns, prefix='', filter_path=None, exclude_url_names=[], exclude_namespaces=[]):
         """
         Uses recursion to flatten url tree.
 
@@ -136,7 +138,7 @@ class UrlParser(object):
             if isinstance(pattern, RegexURLPattern):
                 endpoint_data = self.__assemble_endpoint_data__(pattern, prefix, filter_path=filter_path)
 
-                if endpoint_data is None:
+                if endpoint_data is None or pattern.name in exclude_url_names:
                     continue
 
                 pattern_list.append(endpoint_data)
@@ -151,6 +153,7 @@ class UrlParser(object):
                     pattern.url_patterns,
                     pref,
                     filter_path=filter_path,
+                    exclude_url_names=exclude_url_names,
                     exclude_namespaces=exclude_namespaces,
                 ))
 

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -141,8 +141,10 @@ class SwaggerResourcesView(APIDocView):
     def get_resources(self):
         urlparser = UrlParser()
         urlconf = getattr(self.request, "urlconf", None)
+        exclude_url_names = rfs.SWAGGER_SETTINGS.get('exclude_url_names')
         exclude_namespaces = rfs.SWAGGER_SETTINGS.get('exclude_namespaces')
-        apis = urlparser.get_apis(urlconf=urlconf, exclude_namespaces=exclude_namespaces)
+        apis = urlparser.get_apis(urlconf=urlconf, exclude_url_names=exclude_url_names,
+                                  exclude_namespaces=exclude_namespaces)
         authorized_apis = filter(lambda a: self.handle_resource_access(self.request, a['pattern']), apis)
         authorized_apis_list = list(authorized_apis)
         resources = urlparser.get_top_level_apis(authorized_apis_list)

--- a/tests/auth_example/auth_example/settings.py
+++ b/tests/auth_example/auth_example/settings.py
@@ -168,6 +168,7 @@ LOGGING = {
 }
 
 SWAGGER_SETTINGS = {
+    "exclude_url_names": [],  # List URL names to ignore
     "exclude_namespaces": [],    # List URL namespaces to ignore
     "api_version": '0.1.10',  # Specify your API's version (optional)
     "enabled_methods": [  # Methods to enable in UI

--- a/tests/cigar_example/cigar_example/settings.py
+++ b/tests/cigar_example/cigar_example/settings.py
@@ -171,6 +171,7 @@ LOGGING = {
 }
 
 SWAGGER_SETTINGS = {
+    "exclude_url_names": [],  # List URL names to ignore
     "exclude_namespaces": [],    # List URL namespaces to ignore
     "api_version": '0.1.10',  # Specify your API's version (optional)
     "token_type": 'Bearer',


### PR DESCRIPTION
With this option it is possible to exclude particular views, not only whole namespaces.

https://github.com/marcgibbons/django-rest-swagger/issues/418 related.