### PR TITLE
excluding urls and namespaces from resource-level view as well

### DIFF
--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -169,7 +169,11 @@ class SwaggerApiView(APIDocView):
     def get_apis_for_resource(self, filter_path):
         urlparser = UrlParser()
         urlconf = getattr(self.request, "urlconf", None)
-        apis = urlparser.get_apis(urlconf=urlconf, filter_path=filter_path)
+        exclude_url_names = rfs.SWAGGER_SETTINGS.get('exclude_url_names')
+        exclude_namespaces = rfs.SWAGGER_SETTINGS.get('exclude_namespaces')
+        apis = urlparser.get_apis(urlconf=urlconf, filter_path=filter_path,
+                                  exclude_url_names=exclude_url_names,
+                                  exclude_namespaces=exclude_namespaces)
         authorized_apis = filter(lambda a: self.handle_resource_access(self.request, a['pattern']), apis)
         authorized_apis_list = list(authorized_apis)
         return authorized_apis_list


### PR DESCRIPTION
When using nested namespaces you're unable to exclude lower-level namespaces since the resource view was ignoring the settings.

I'm not sure if this was intended or not, but I needed it for my purposes.