### PR TITLE
Fix bug in Django 1.9 when using ListFields

### DIFF
--- a/rest_framework_swagger/static/rest_framework_swagger/lib/swagger.js
+++ b/rest_framework_swagger/static/rest_framework_swagger/lib/swagger.js
@@ -694,7 +694,7 @@ var SwaggerOperation = function(nickname, path, method, parameters, summary, not
 
     // for 1.1 compatibility
     var type = param.type || param.dataType;
-    if(type === 'array') {
+    if(type === 'array' && 'items' in param) {
       type = 'array[' + (param.items.$ref ? param.items.$ref : param.items.type) + ']';
     }
     param.type = type;


### PR DESCRIPTION
Without it, we see "TypeError: params.items is undefined" in JS Console.
Tested with Django 1.9.4, DRF 3.3.2 and django-rest-swagger 0.3.5.