### PR TITLE
Add support for making API paths relative to the specified api_path setting

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -12,6 +12,7 @@ Example:
         'exclude_namespaces': [],
         'api_version': '0.1',
         'api_path': '/',
+        'relative_paths': False,
         'enabled_methods': [
             'get',
             'post',
@@ -153,6 +154,13 @@ Then in app/views.py:
     def permission_denied_handler(request):
         from django.http import HttpResponse
         return HttpResponse('you have no permissions!')
+
+relative_paths
+--------------
+
+set to True to make API paths relative to specified :code:`api_path`.
+
+Default: :code:`False`
 
 resource_access_handler
 -------------------------

--- a/rest_framework_swagger/__init__.py
+++ b/rest_framework_swagger/__init__.py
@@ -6,6 +6,7 @@ DEFAULT_SWAGGER_SETTINGS = {
     'api_version': '',
     'api_path': '/',
     'api_key': '',
+    'relative_paths': False,
     'token_type': 'Token',
     'enabled_methods': ['get', 'post', 'put', 'patch', 'delete'],
     'is_authenticated': False,

--- a/rest_framework_swagger/urlparser.py
+++ b/rest_framework_swagger/urlparser.py
@@ -1,10 +1,10 @@
 import re
 import os
 from importlib import import_module
-from urlparse import urljoin
 
 from django.conf import settings
 from django.utils import six
+from django.utils.six.moves.urllib_parse import urljoin
 from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
 from django.contrib.admindocs.views import simplify_regex
 

--- a/rest_framework_swagger/urlparser.py
+++ b/rest_framework_swagger/urlparser.py
@@ -1,6 +1,7 @@
 import re
 import os
 from importlib import import_module
+from urlparse import urljoin
 
 from django.conf import settings
 from django.utils import six
@@ -10,11 +11,16 @@ from django.contrib.admindocs.views import simplify_regex
 from rest_framework.views import APIView
 
 from .apidocview import APIDocView
+from . import SWAGGER_SETTINGS
 
 
 class UrlParser(object):
 
-    def get_apis(self, patterns=None, urlconf=None, filter_path=None, exclude_url_names=None, exclude_namespaces=None):
+    __relative_path_matcher__ = re.compile(
+        r'^%s(?P<relative>.*)' % SWAGGER_SETTINGS.get('api_path', ''))
+
+    def get_apis(self, patterns=None, urlconf=None, filter_path=None,
+                 exclude_url_names=None, exclude_namespaces=None):
         """
         Returns all the DRF APIViews found in the project URLs
 
@@ -24,6 +30,8 @@ class UrlParser(object):
         """
         exclude_url_names = exclude_url_names or []
         exclude_namespaces = exclude_namespaces or []
+        filter_path = self.__make_absolute__(filter_path)
+
         if patterns is None and urlconf is not None:
             if isinstance(urlconf, six.string_types):
                 urls = import_module(urlconf)
@@ -41,6 +49,7 @@ class UrlParser(object):
             exclude_namespaces=exclude_namespaces,
         )
         if filter_path is not None:
+            filter_path = self.__make_relative__(filter_path, strip=True)
             return self.get_filtered_apis(apis, filter_path)
 
         return apis
@@ -117,6 +126,7 @@ class UrlParser(object):
                 return None
 
         path = path.replace('<', '{').replace('>', '}')
+        path = self.__make_relative__(path)
 
         if self.__exclude_format_endpoints__(path):
             return
@@ -127,7 +137,8 @@ class UrlParser(object):
             'callback': callback,
         }
 
-    def __flatten_patterns_tree__(self, patterns, prefix='', filter_path=None, exclude_url_names=None, exclude_namespaces=None):
+    def __flatten_patterns_tree__(self, patterns, prefix='', filter_path=None,
+                                  exclude_url_names=None, exclude_namespaces=None):
         """
         Uses recursion to flatten url tree.
 
@@ -140,7 +151,8 @@ class UrlParser(object):
 
         for pattern in patterns:
             if isinstance(pattern, RegexURLPattern):
-                endpoint_data = self.__assemble_endpoint_data__(pattern, prefix, filter_path=filter_path)
+                endpoint_data = self.__assemble_endpoint_data__(
+                    pattern, prefix, filter_path=filter_path)
 
                 if endpoint_data is None or pattern.name in exclude_url_names:
                     continue
@@ -149,7 +161,8 @@ class UrlParser(object):
 
             elif isinstance(pattern, RegexURLResolver):
 
-                if pattern.namespace is not None and pattern.namespace in exclude_namespaces:
+                if pattern.namespace is not None \
+                        and pattern.namespace in exclude_namespaces:
                     continue
 
                 pref = prefix + pattern.regex.pattern
@@ -200,3 +213,24 @@ class UrlParser(object):
             return True
 
         return False
+
+    def __make_relative__(self, path, strip=False):
+        """
+        When `relative_paths` is True, make path relative to API Path.
+        """
+        if path:
+            if SWAGGER_SETTINGS.get('relative_paths', False):
+                res = UrlParser.__relative_path_matcher__.match(path)
+                path = urljoin('/', res.groups()[0]) if res else path
+
+            return path.strip('/') if strip else path
+
+    def __make_absolute__(self, path):
+        """
+        When `relative_paths` is True, fully qualify path with API Path.
+        """
+        if path:
+            if SWAGGER_SETTINGS.get('relative_paths', False):
+                path = urljoin(SWAGGER_SETTINGS.get('api_path'), path)
+
+            return path


### PR DESCRIPTION
I ran into an issue with DRS, when coupled with the excellent [swagger-codegen](https://github.com/swagger-api/swagger-codegen) project.

My URI scheme prefixes the API, in the format of `/api/v1/foo`. Generated URIs retrieved from the DRF routers fully qualify ViewSets with this prefix.

With the `api_path` set to default (`/`), full paths appear in the generated docs. This means that swagger-codegen parses the name incorrectly, as it always expects resources to be relative to their base path.

Also, if i do set the `api_path` to be `/api/v1/foo`, generated client libraries try to access the resource at `/api/v1/foo/api/v1/foo/resource`. I think this behaviour is incorrect, as the APIs are supposed to be relative to the resource `basePath`.

This PR adds support for this functionality. With the new `relative_paths` setting set to `True`, URIs shall be relative to the `api_path` setting. Default value is `False`, to preserve existing behaviour.