### PR TITLE
Added support for array type responses

### DIFF
--- a/docs/source/misc.rst
+++ b/docs/source/misc.rst
@@ -6,7 +6,7 @@ Markdown
 django-rest-swagger will parse docstrings as markdown if `Markdown <https://pypi.python.org/pypi/Markdown>`_ is installed.
 
 reStructuredText
------------------
+----------------
 django-rest-swagger can be configured to parse docstrings as reStructuredText.
 
 Add to your settings:
@@ -18,7 +18,7 @@ Add to your settings:
     }
 
 Swagger 'nickname' attribute
------------------
+----------------------------
 By default, django-rest-swagger uses django-rest-framework's get_view_name to resolve the `nickname` attribute
 of a Swagger operation. You can specify an alternative function for `nickname` resolution using the following setting:
 
@@ -37,3 +37,17 @@ This function should use the following signature:
 -:code:`cls` The view class providing the operation.
 
 -:code:`suffix` The string name of the class method which is providing the operation.
+
+
+Swagger 'list' views
+--------------------
+
+django-rest-swagger introspects your views and viewset methods in order to determine the serializer used.
+
+In the majority of cases, the object returned is a single type. However, there are times where multiple serialized
+objects can be returned, such as in the case of `list` methods.
+
+When you use ViewSets, django-rest-swagger will report that the `list` method on a viewset returns a list of objects.
+
+For other ViewSet methods or function based views, you can also hint to django-rest-swagger that the view response is
+also a list, rather than a single object. See :ref:`many`

--- a/docs/source/yaml.rst
+++ b/docs/source/yaml.rst
@@ -30,6 +30,7 @@ Example:
 
         serializer: .serializers.FooSerializer
         omit_serializer: false
+        many: true
 
         parameters_strategy: merge
         omit_parameters:
@@ -97,7 +98,7 @@ to populate :code:`type` you can specify it with :code:`pytype`:
     pytype: .serializers.FooSerializer
 
 Overriding parameters
---------------------
+---------------------
 
 parameters_strategy
 ~~~~~~~~~~~~~~~~~~~
@@ -175,6 +176,23 @@ signature as follows:
       url:
         required: false
         type: url
+
+.. _many:
+
+many
+----
+
+In cases where an API response is a list of objects, it is possible to mark
+this to django-rest-swagger by overriding :code:`many` to `True`.
+
+.. code-block:: yaml
+
+    many: true
+
+This overrides the :code:`type` returned to be an array of the resolved API
+type. ViewSet :code:`list` methods do not require this definition, and are
+marked as :code:`many` automatically.
+
 
 responseMessages 
 ---------------------------------

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -118,6 +118,14 @@ class DocumentationGenerator(object):
             if produces:
                 operation['produces'] = produces
 
+            # Check if this method has been reported as returning an
+            # array response
+            if method_introspector.is_array_response:
+                operation['items'] = {
+                    '$ref': operation['type']
+                }
+                operation['type'] = 'array'
+
             operations.append(operation)
 
         return operations

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -181,6 +181,11 @@ class BaseMethodIntrospector(object):
         self.path = view_introspector.path
         self.user = view_introspector.user
 
+    @property
+    def is_array_response(self):
+        """ Support definition of array responses with the 'many' attr """
+        return self.get_yaml_parser().object.get('many')
+
     def get_module(self):
         return self.callback.__module__
 
@@ -647,6 +652,12 @@ class ViewSetMethodIntrospector(BaseMethodIntrospector):
         super(ViewSetMethodIntrospector, self) \
             .__init__(view_introspector, method)
         self.http_method = http_method.upper()
+
+    @property
+    def is_array_response(self):
+        """ ViewSet.list methods always return array responses """
+        return (self.method == 'list' or
+                super(ViewSetMethodIntrospector, self).is_array_response)
 
     def get_http_method(self):
         return self.http_method


### PR DESCRIPTION
Another one I needed - support for Arrays.

DRS doesn't make any attempt at the moment to discern if a view returns an array of Serializer objects. This is problematic when used with `swagger-codegen`, as APIs which are supposed to return lists of objects don't say that they do, and codegen expects a single object response.

I did see a similar PR #404, but this has been open for several months with no activity and I needed this for my own purposes now.

What this PR does that the other does not, is push inspection into the introspection layer. In addition, viewset methods named `list` are automatically made into array responses (as they always are with DRF). I've taken the concept of applying 'many' to the YAML docstring stanza as well, to allow FBVs and other detail / list routes in viewsets to work.

I've also added an expanded information section in `misc.rst`, with cross-referenced expansion on the `many` yaml attribute in `yaml.rst`.

Any questions, give me a shout.