### PR TITLE
Primitive list fields 413

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -277,6 +277,8 @@ class DocumentationGenerator(object):
 
         serializers_set = set()
         for serializer in serializers:
+            if not hasattr(serializer, 'get_fields'):
+                continue
             fields = serializer().get_fields()
             for name, field in fields.items():
                 if isinstance(field, BaseSerializer):
@@ -296,7 +298,9 @@ class DocumentationGenerator(object):
         if serializer is None:
             return
 
-        if hasattr(serializer, '__call__'):
+        if not hasattr(serializer, 'get_fields'):
+            fields = {}
+        elif callable(serializer):
             fields = serializer().get_fields()
         else:
             fields = serializer.get_fields()

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -379,12 +379,16 @@ class DocumentationGenerator(object):
 
             if isinstance(field, BaseSerializer) or has_many:
                 if isinstance(field, BaseSerializer):
-                    field_serializer = IntrospectorHelper.get_serializer_name(field)
+                    if isinstance(field, ListSerializer) and not isinstance(field.child, BaseSerializer):
+                        data_type, data_format = get_data_type(field.child)
+                        field_serializer = None
+                    else:
+                        field_serializer = IntrospectorHelper.get_serializer_name(field)
 
-                    if getattr(field, 'write_only', False):
-                        field_serializer = "Write{}".format(field_serializer)
+                        if getattr(field, 'write_only', False):
+                            field_serializer = "Write{}".format(field_serializer)
 
-                    f['type'] = field_serializer
+                        f['type'] = field_serializer
                 else:
                     field_serializer = None
                     data_type = 'string'

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -383,8 +383,10 @@ class DocumentationGenerator(object):
 
             if isinstance(field, BaseSerializer) or has_many:
                 if isinstance(field, BaseSerializer):
-                    from rest_framework.serializers import ListSerializer
-                    if isinstance(field, ListSerializer) and not isinstance(field.child, BaseSerializer):
+                    if (rest_framework.VERSION >= '3.0.0' and
+                        isinstance(field, ListSerializer) and
+                        not isinstance(field.child, BaseSerializer)):
+
                         data_type, data_format = get_data_type(field.child)
                         field_serializer = None
                     else:

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -383,6 +383,7 @@ class DocumentationGenerator(object):
 
             if isinstance(field, BaseSerializer) or has_many:
                 if isinstance(field, BaseSerializer):
+                    from rest_framework.serializers import ListSerializer
                     if isinstance(field, ListSerializer) and not isinstance(field.child, BaseSerializer):
                         data_type, data_format = get_data_type(field.child)
                         field_serializer = None

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -384,8 +384,8 @@ class DocumentationGenerator(object):
             if isinstance(field, BaseSerializer) or has_many:
                 if isinstance(field, BaseSerializer):
                     if (rest_framework.VERSION >= '3.0.0' and
-                        isinstance(field, ListSerializer) and
-                        not isinstance(field.child, BaseSerializer)):
+                            isinstance(field, ListSerializer) and
+                            not isinstance(field.child, BaseSerializer)):
 
                         data_type, data_format = get_data_type(field.child)
                         field_serializer = None


### PR DESCRIPTION
As shown in [issue 413](https://github.com/marcgibbons/django-rest-swagger/issues/413), ListField with non-serializer child causes an error. Here is the fix.