### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ From pip:
 pip install django-rest-swagger
 
 Project @ https://github.com/marcgibbons/django-rest-swagger
-Docs @ http://django-rest-swagger.readthedocs.org/
+Docs @ https://django-rest-swagger.readthedocs.io/
 """
 
 # allow setup.py to be run from any path


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.