### PR TITLE
Fixed support for Django 1.10

### DIFF
--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -5,7 +5,8 @@ from django.conf import settings
 from django.views.generic import View
 from django.utils.safestring import mark_safe
 from django.utils.encoding import smart_text
-from django.shortcuts import render_to_response, RequestContext
+from django.shortcuts import render_to_response
+from django.template import RequestContext
 from django.core.exceptions import PermissionDenied
 from .compat import import_string
 


### PR DESCRIPTION
This fixes #452.

However, the testing matrix has not been updated to include 1.10, or 1.9, as I was running into some rather large issues with the test suite and attempting to maintain compatibility with Django >= 1.5. There may need to be a fairly rewrite of the test suite when support is switched to modern Django versions.

That said, this does work for me in my own Django 1.10a1 application, and still passes tests using Django 1.5.