### PR TITLE
request_serializer support for GET, DELETE and HEAD queries

### DIFF
--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -507,6 +507,7 @@ class BaseMethodIntrospector(object):
         """
         return self.build_serializer_parameters('form')
 
+
 def get_primitive_type(var):
     if isinstance(var, bool):
         return 'boolean', 'boolean'

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -1730,9 +1730,9 @@ class YAMLDocstringParserTests(TestCase, DocumentationGeneratorMixin):
         class SerializedAPI(ListCreateAPIView):
             serializer_class = CommentSerializer
 
-            def get(self, request, *args, **kwargs):
+            def post(self, request, *args, **kwargs):
                 """
-                My list view with custom query parameters
+                My create view with custom query parameters
 
                 ---
                 parameters_strategy:
@@ -1750,7 +1750,7 @@ class YAMLDocstringParserTests(TestCase, DocumentationGeneratorMixin):
                     request, *args, **kwargs)
 
         class_introspector = self.make_introspector(SerializedAPI)
-        introspector = APIViewMethodIntrospector(class_introspector, 'GET')
+        introspector = APIViewMethodIntrospector(class_introspector, 'POST')
         parser = introspector.get_yaml_parser()
         params = introspector.build_form_parameters()
         self.assertEqual(len(CommentSerializer().get_fields()), len(params))


### PR DESCRIPTION
`request_serializer` fields are added to the query params when the http request method is one of `GET`, `DELETE` or `HEAD`