### PR TITLE
Fix child field instantiation with missing arguments

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -271,7 +271,7 @@ class DocumentationGenerator(object):
         def get_thing(field, key):
             if rest_framework.VERSION >= '3.0.0':
                 from rest_framework.serializers import ListSerializer
-                if isinstance(field, ListSerializer):
+                if isinstance(field, ListSerializer) and isinstance(field.child, BaseSerializer):
                     return key(field.child)
             return key(field)
 


### PR DESCRIPTION
docgenerator.py:
```
    def _find_field_serializers(self, serializers, found_serializers=set()):
        """
        Returns set of serializers discovered from fields
        """
        ...
            fields = serializer().get_fields()
```

provokes an instantiation error (`AssertionError: The `slug_field` argument is required.`), when a `ListSerializer` is used with a `child` field that is not a serializer and that expects mandatory arguments in its constructor.

django-rest-swagger wrongly assumes the child to be a serializer and thus to be callable without arguments.

Example:
```
class ProfileSerializer(serializers.ModelSerializer):
    interests = DictionarySerializer(child=serializers.SlugRelatedField(slug_field='title', queryset=Discipline.objects.all()))
```

Therefore, add a test for `child` to inherit from `BaseSerializer`.