### PR TITLE
Fix reStructuredText and other formatting

### DIFF
--- a/docs/source/misc.rst
+++ b/docs/source/misc.rst
@@ -3,7 +3,15 @@ Miscellaneous
 Markdown
 --------
 
-django-rest-swagger will parse docstrings as markdown if `Markdown <https://pypi.python.org/pypi/Markdown>`_ is installed.
+django-rest-swagger will parse docstrings as markdown if `Markdown <https://pypi.python.org/pypi/Markdown>`_ is installed and the view description function is set to `rest_framework.views.get_view_description` (which is the default).
+
+Add to your settings:
+
+.. code-block:: python
+
+    REST_FRAMEWORK = {
+        'VIEW_DESCRIPTION_FUNCTION': 'rest_framework.views.get_view_description'  # default
+    }
 
 reStructuredText
 ----------------

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -17,7 +17,7 @@ from django.utils.encoding import smart_text
 
 import rest_framework
 from rest_framework import viewsets
-from rest_framework.compat import apply_markdown
+
 try:
     from rest_framework.fields import CurrentUserDefault
 except ImportError:
@@ -298,9 +298,9 @@ class BaseMethodIntrospector(object):
                 method_docs
             )
             docstring += '\n' + method_docs
-        docstring = docstring.strip()
+        docstring = get_view_description(self.callback, html=True, docstring=docstring)
 
-        return do_markdown(docstring)
+        return docstring.strip()
 
     def get_parameters(self):
         """
@@ -584,14 +584,6 @@ class WrappedAPIViewIntrospector(BaseViewIntrospector):
             class_docs)
         return get_view_description(
             self.callback, html=True, docstring=class_docs)
-
-
-def do_markdown(docstring):
-    # Markdown is optional
-    if apply_markdown:
-        return apply_markdown(docstring)
-    else:
-        return docstring.replace("\n\n", "<br/>")
 
 
 class APIViewMethodIntrospector(BaseMethodIntrospector):

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -2641,6 +2641,21 @@ class RESTDocstringTests(TestCase):
         self.assertIn('Oh yes this is reST', docs)
         self.assertIn('Oh yes so is this', docs)
 
+    def test_use_view_function(self):
+        class MyViewSet(ModelViewSet):
+            """
+            **this is bold**
+            """
+            model = User
+            serializer_class = CommentSerializer
+            paginate_by = 20
+            paginate_by_param = 'page_this_by'
+
+        class_introspector = make_viewset_introspector(MyViewSet)
+        introspector = get_introspectors(class_introspector)['create']
+        docs = introspector.get_notes()
+        self.assertEqual('<p><strong>this is bold</strong></p>', docs)
+
 
 def get_custom_description(view_cls, html=False):
     description = view_cls.__doc__ or ''


### PR DESCRIPTION
Addresses issue #407 

reStructuredText was not rendering because the view description function (the rst formatter) was never been called in `BaseMethodIntrospector.get_notes`.

`get_notes` would always call `do_markdown`. We could call the view description function before calling `do_markdown` but this may lead to situations where we apply rst and then markdown.

I suggest that the view description function be used for all formatting, whether this be markdown, rst, or other. By default, the view description function is `rest_framework.views.get_view_description`.

There is one slight formatting change from this pull request. If markdown is disabled, `do_markdown` was doing `replace('\n\n', '<br />')` but `rest_framework.views.get_view_description` does `replace('\n', '<br />')`. Will this be an issue?