### PR TITLE
Changes for support django 1.9.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
-Django==1.7.1
+Django>=1.7.1
 Markdown==2.1.1
 PyYAML==3.11
 argh==0.23.2
 argparse==1.2.1
 coverage==3.6
-django-nose==1.2
+django-nose>=1.2
 djangorestframework>=2.3.8
 django-filter==0.11.0
 jsonschema==2.5
-nose==1.3.0
+nose>=1.3.0
 mock==1.0.1
 ordereddict==1.1
 docutils>=0.11

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -19,7 +19,11 @@ from django.contrib.admindocs.utils import trim_docstring
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.decorators import classonlymethod
-from django.utils.importlib import import_module
+try:
+    from django.utils.module_loading import import_module
+except ImportError:
+    from django.utils.importlib import import_module
+
 from django.views.generic import View
 import django_filters
 


### PR DESCRIPTION
I tried runtests.py based on django 1.9.x, and there are some errors related with unsupported libraries.
Please review on whether there is any problem.