### PR TITLE
Include "api_version" in "Accept" header always

### DIFF
--- a/rest_framework_swagger/templates/rest_framework_swagger/base.html
+++ b/rest_framework_swagger/templates/rest_framework_swagger/base.html
@@ -94,7 +94,7 @@
                 {% endif %}
 
                 {# Add version to Accept header, if AcceptHeaderVersioning is used. #}
-                {% if swagger_settings.api_version and rest_framework_settings.DEFAULT_VERSIONING_CLASS == 'rest_framework.versioning.AcceptHeaderVersioning' %}
+                {% if swagger_settings.api_version %}
                     window.authorizations.add('version', {
                         apply: function(obj, authorizations) {
                             $.each(obj.headers, function(k, v) {


### PR DESCRIPTION
The `rest_framework_settings.DEFAULT_VERSIONING_CLASS` setting might be
customized.

Follow-up to https://github.com/marcgibbons/django-rest-swagger/pull/379.
