### PR TITLE
Feature/auto detect hosts

### DIFF
--- a/rest_framework_swagger/renderers.py
+++ b/rest_framework_swagger/renderers.py
@@ -33,7 +33,8 @@ class OpenAPIRenderer(BaseRenderer):
         Adds settings, overrides, etc. to the specification.
         """
         self.add_security_definitions(data)
-        data['host'] = self.get_host(renderer_context['request'])
+        if not data.get('host'):
+            data['host'] = self.get_host(renderer_context)
 
     def add_security_definitions(self, data):
         if not swagger_settings.SECURITY_DEFINITIONS:
@@ -41,8 +42,8 @@ class OpenAPIRenderer(BaseRenderer):
 
         data['securityDefinitions'] = swagger_settings.SECURITY_DEFINITIONS
 
-    def get_host(self, request):
-        return request.get_host()
+    def get_host(self, renderer_context):
+        return renderer_context['request'].get_host()
 
 
 class SwaggerUIRenderer(BaseRenderer):

--- a/rest_framework_swagger/renderers.py
+++ b/rest_framework_swagger/renderers.py
@@ -14,7 +14,7 @@ class OpenAPIRenderer(BaseRenderer):
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         data = self.get_openapi_specification(data)
-        self.add_customizations(data)
+        self.add_customizations(data, renderer_context)
 
         return self.dump(data)
 
@@ -28,17 +28,21 @@ class OpenAPIRenderer(BaseRenderer):
         codec = OpenAPICodec()
         return json.loads(codec.dump(data))
 
-    def add_customizations(self, data):
+    def add_customizations(self, data, renderer_context):
         """
         Adds settings, overrides, etc. to the specification.
         """
         self.add_security_definitions(data)
+        data['host'] = self.get_host(renderer_context['request'])
 
     def add_security_definitions(self, data):
         if not swagger_settings.SECURITY_DEFINITIONS:
             return
 
         data['securityDefinitions'] = swagger_settings.SECURITY_DEFINITIONS
+
+    def get_host(self, request):
+        return request.get_host()
 
 
 class SwaggerUIRenderer(BaseRenderer):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+import os
+
+os.environ.setdefault(
+    'DJANGO_SETTINGS_MODULE',
+    'example_app.tutorial.settings'
+)

--- a/tests/renderers/test_openapi_renderer.py
+++ b/tests/renderers/test_openapi_renderer.py
@@ -28,6 +28,7 @@ class TestOpenAPIRenderer(TestCase):
 
     def test_render(self):
         data = MagicMock()
+        renderer_context = {'request': MagicMock()}
 
         with patch.multiple(
             self.sut,
@@ -35,11 +36,14 @@ class TestOpenAPIRenderer(TestCase):
             add_customizations=DEFAULT,
             dump=DEFAULT
         ) as values:
-            self.sut.render(data)
+            self.sut.render(data, renderer_context=renderer_context)
 
         values['get_openapi_specification'].assert_called_once_with(data)
         data = values['get_openapi_specification'].return_value
-        values['add_customizations'].assert_called_once_with(data)
+        values['add_customizations'].assert_called_once_with(
+            data,
+            renderer_context
+        )
         values['dump'].assert_called_once_with(data)
 
     @patch('rest_framework_swagger.renderers.force_bytes')
@@ -68,8 +72,9 @@ class TestOpenAPIRenderer(TestCase):
 
     def test_add_customizations(self):
         data = MagicMock()
+        renderer_context = {'request': MagicMock()}
         with patch.object(self.sut, 'add_security_definitions') as mock:
-            self.sut.add_customizations(data)
+            self.sut.add_customizations(data, renderer_context)
 
         mock.assert_called_once_with(data)
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist =
     lint
 
 [testenv]
-setenv = DJANGO_SETTINGS_MODULE=example_app.tutorial.settings
 commands = python -m unittest discover
 deps =
     coreapi
@@ -19,7 +18,6 @@ deps =
     mock
 
 [testenv:latest]
-setenv = DJANGO_SETTINGS_MODULE=example_app.tutorial.settings
 commands = coverage run -m unittest discover
 deps = 
     Django
@@ -32,9 +30,7 @@ deps =
 
 [testenv:py27]
 commands = python -m unittest discover
-setenv = DJANGO_SETTINGS_MODULE=example_app.tutorial.settings
 
 [testenv:lint]
 commands = pylint rest_framework_swagger tests
-setenv = DJANGO_SETTINGS_MODULE=example_app.tutorial.settings
 deps = -rrequirements.txt


### PR DESCRIPTION
Fixes #482 
- Uses `host` returned by the openapi codec if present and its value is truthy
- Falls back onto the renderer context's view request; uses `request.get_host()` to set value.