### PR TITLE
Required filter fields

### DIFF
--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -413,6 +413,7 @@ class BaseMethodIntrospector(object):
                 parameter = {
                     'paramType': 'query',
                     'name': name,
+                    'required': filter_.required,
                     'description': filter_.label,
                 }
                 normalize_data_format(data_type, None, parameter)

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -1079,7 +1079,9 @@ class ViewSetMethodIntrospectorTests(TestCase):
                 label='Choices of possible first names',
                 choices=(('foo', 'Foo'),
                          ('bar', 'Bar')
-                         ))
+                         ),
+                required=True
+            )
 
         class MyViewSet(ModelViewSet):
             model = User
@@ -1093,13 +1095,15 @@ class ViewSetMethodIntrospectorTests(TestCase):
                          [{'paramType': 'query',
                            'name': 'username',
                            'description': 'Username of User',
-                           'type': 'string'
+                           'type': 'string',
+                           'required': False
                            },
                           {'paramType': 'query',
                            'name': 'choices',
                            'description': 'Choices of possible first names',
                            'enum': ['foo', 'bar'],
-                           'type': 'enum'
+                           'type': 'enum',
+                           'required': True
                            }
                           ])
 


### PR DESCRIPTION
Implemented support for 'required' argument in FilterSet fields.
E.g.:
```python
class GameFieldsFilter(django_filters.FilterSet):
    latitude = django_filters.NumberFilter(name='location', required=False)
    longitude = django_filters.NumberFilter(name='location', required=True)
    span_latitude = django_filters.NumberFilter(name='location', required=True)
    span_longitude = django_filters.NumberFilter(name='location', required=True)
```

Was:
![Image](http://image.prntscr.com/image/10bb2c5c3b3a4cdbb06a6b48132914d3.png)

Now:
![Image](http://image.prntscr.com/image/ca1c8c855b2842c38862b42b04a096eb.png)