### PR TITLE
Render schema directly using codec.

### DIFF
--- a/rest_framework_swagger/renderers.py
+++ b/rest_framework_swagger/renderers.py
@@ -18,23 +18,16 @@ class OpenAPIRenderer(BaseRenderer):
         if renderer_context['response'].status_code != status.HTTP_200_OK:
             return self.dump(data)
 
-        data = self.get_openapi_specification(data)
-        self.add_customizations(data, renderer_context)
-        return self.dump(data)
-
-    def dump(self, data):
-        return force_bytes(json.dumps(data))
-
-    def get_openapi_specification(self, data):
-        """
-        Converts data into OpenAPI specification.
-        """
         assert isinstance(data, coreapi.Document), (
             'Expected a coreapi.Document, but received %s instead.' %
             type(data)
         )
-        codec = OpenAPICodec()
-        return json.loads(codec.dump(data))
+        title = data.title
+        url = data.url
+        content = dict(data)
+        self.add_customizations(content, renderer_context)
+        doc = coreapi.Document(title=title, url=url, content=content)
+        return OpenAPICodec().encode(doc)
 
     def add_customizations(self, data, renderer_context):
         """


### PR DESCRIPTION
Currently we add extra data by:

* Dumping the schema with the codec.
* Loading the JSON from that.
* Modifying the data.
* Dump the JSON.

Instead we should:

* Create a new document based on the existing document, but with modified data.
* Use the codec to dump the schema.

For example, this allows the codec to ensure nice a JSON ordering based on the swagger paths, where the naive JSON dump cannot.

See also https://github.com/core-api/python-openapi-codec/pull/14