### PR TITLE
Trust `base_url` if it starts with https?://

### DIFF
--- a/rest_framework_swagger/__init__.py
+++ b/rest_framework_swagger/__init__.py
@@ -1,4 +1,4 @@
-VERSION = '0.3.10'
+VERSION = '0.3.11'
 
 DEFAULT_SWAGGER_SETTINGS = {
     'exclude_url_names': [],

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -138,6 +138,8 @@ class SwaggerResourcesView(APIDocView):
             return self.request.build_absolute_uri(
                 self.request.path).rstrip('/')
         else:
+            if base_path.startswith('http://') or base_path.startswith('https://'):
+                return '{0}/{1}'.format(base_path.rstrip('/'), 'api-docs')
             protocol = 'https' if self.request.is_secure() else 'http'
             return '{0}://{1}/{2}'.format(protocol, base_path, 'api-docs')
 

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -49,7 +49,7 @@ def get_full_base_path(request):
         return request.build_absolute_uri(request.path).rstrip('/')
     else:
         if base_path.startswith('http://') or base_path.startswith('https://'):
-            return base_path
+            return base_path.rstrip('/')
         protocol = 'https' if request.is_secure() else 'http'
         return '{0}://{1}'.format(protocol, base_path.rstrip('/'))
 

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -48,6 +48,8 @@ def get_full_base_path(request):
     except KeyError:
         return request.build_absolute_uri(request.path).rstrip('/')
     else:
+        if base_path.startswith('http://') or base_path.startswith('https://'):
+            return base_path
         protocol = 'https' if request.is_secure() else 'http'
         return '{0}://{1}'.format(protocol, base_path.rstrip('/'))
 


### PR DESCRIPTION
If the `base_url` is set to start with https?://, the deployer should know what he is doing, and hence it should not be set doubted by prepending https?:// depending on the original request's protocol.

The request protocol might have been altered by a proxy which transfers https to http, making traffic at the server seem http, while the internet sees it as https.