### PR TITLE
Minimum DRF version to 3.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Full documentation: http://marcgibbons.github.io/django-rest-swagger/
 
-**Note:** you are viewing documentation for version 2, using Django REST Framework 3.4+ and CoreAPI. Documentation for previous versions is available [here](http://django-rest-swagger.readthedocs.io/en/stable-0.3.x/).
+**Note:** you are viewing documentation for version 2, using Django REST Framework 3.4.1+ and CoreAPI. Documentation for previous versions is available [here](http://django-rest-swagger.readthedocs.io/en/stable-0.3.x/).
 
 
 ## Installation
@@ -53,7 +53,7 @@ urlpatterns = [
 
 ## Requirements
 * Django 1.8+
-* Django REST framework 3.4+
+* Django REST framework 3.4.1+
 * Python 2.7, 3.5
 
 


### PR DESCRIPTION
I noticed that https://github.com/tomchristie/django-rest-framework/blob/3.4.0/rest_framework/schemas.py#L60 is missing the `url` kwarg (introduced in 3.4.1) that DRS relies on. Perhaps either the code or the README should be modified to resolve this dependency?