### PR TITLE
Restore swagger shortcut view

### DIFF
--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -1,19 +1,41 @@
-from rest_framework import schemas
+from rest_framework import exceptions
+from rest_framework.permissions import AllowAny
 from rest_framework.renderers import CoreJSONRenderer
+from rest_framework.response import Response
+from rest_framework.schemas import SchemaGenerator
+from rest_framework.views import APIView
 
 from . import renderers
 
 
-def get_swagger_view(title=None, url=None):
+def get_swagger_view(title=None, url=None, patterns=None, urlconf=None):
     """
     Returns schema view which renders Swagger/OpenAPI.
     """
-    return schemas.get_schema_view(
-        title=title,
-        url=url,
-        renderer_classes=[
+    class SwaggerSchemaView(APIView):
+        _ignore_model_permissions = True
+        exclude_from_schema = True
+        permission_classes = [AllowAny]
+        renderer_classes = [
             CoreJSONRenderer,
             renderers.OpenAPIRenderer,
             renderers.SwaggerUIRenderer
         ]
-    )
+
+        def get(self, request):
+            generator = SchemaGenerator(
+                title=title,
+                url=url,
+                patterns=patterns,
+                urlconf=urlconf
+            )
+            schema = generator.get_schema(request=request)
+
+            if not schema:
+                raise exceptions.ValidationError(
+                    'The schema generator did not return a schema Document'
+                )
+
+            return Response(schema)
+
+    return SwaggerSchemaView.as_view()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
-from rest_framework import schemas
+from rest_framework.permissions import AllowAny
 from rest_framework.renderers import CoreJSONRenderer
+from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
 from rest_framework_swagger import renderers
@@ -15,22 +16,66 @@ class TestGetSwaggerView(TestCase):
         self.factory = APIRequestFactory()
         self.view_class = self.sut().cls
 
-    def test_returns_get_schema_view(self):
-        title = 'Vandelay Industries API',
-        url = 'http://vandelay.industries'
-        renderer_classes = [
-            CoreJSONRenderer,
-            renderers.OpenAPIRenderer,
-            renderers.SwaggerUIRenderer
-        ]
+    def test_title_and_urlpassed_to_schema_generator(self):
+        title = 'Vandelay'
+        url = 'https://github.com/marcgibbons/django-rest-swagger'
+        view = self.sut(title=title, url=url)
 
-        with patch.object(schemas, 'get_schema_view') as mock:
-            result = self.sut(title=title, url=url)
+        with patch('rest_framework_swagger.views.SchemaGenerator') as mock:
+            request = self.factory.get('/')
+            view(request=request)
 
-        mock.assert_called_once_with(
-            title=title,
-            url=url,
-            renderer_classes=renderer_classes
+        mock.assert_called_once_with(title=title, url=url)
+
+    def test_ignore_model_permissions_true(self):
+        self.assertTrue(self.view_class._ignore_model_permissions)
+
+    def test_exclude_from_schema(self):
+        self.assertTrue(self.view_class.exclude_from_schema)
+
+    def test_renderer_classes(self):
+        self.assertListEqual(
+            [
+                CoreJSONRenderer,
+                renderers.OpenAPIRenderer,
+                renderers.SwaggerUIRenderer
+            ],
+            self.view_class.renderer_classes
         )
 
-        self.assertEqual(mock.return_value, result)
+    def test_permission_class(self):
+        self.assertListEqual(
+            [AllowAny],
+            self.view_class.permission_classes
+        )
+
+    def test_return_400_if_schema_is_none(self):
+        with patch('rest_framework_swagger.views.SchemaGenerator') as mock:
+            mock.return_value.get_schema.return_value = None
+            request = self.factory.get('/')
+            response = self.sut()(request=request)
+
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            ['The schema generator did not return a schema Document'],
+            response.data
+        )
+
+    def test_response_is_result_of_schema_generator(self):
+        expected = 'My amazing schema'
+        with patch('rest_framework_swagger.views.SchemaGenerator') as mock:
+            mock.return_value.get_schema.return_value = expected
+            request = self.factory.get('/')
+            response = self.sut()(request=request)
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(expected, response.data)
+
+    def test_schema_generator_instantiated_with_request(self):
+        with patch('rest_framework_swagger.views.SchemaGenerator') as mock:
+            request = self.factory.get('/')
+            self.sut()(request=request)
+
+        call_args = mock.return_value.get_schema.call_args[1]
+        self.assertIn('request', call_args)
+        self.assertIsInstance(call_args['request'], Request)


### PR DESCRIPTION
- Decouple `get_swagger_view` from the DRF `get_schema_view`. Add default permission of AllowAny, but enforce endpoint-level permissions
- Expose DRF schema generator init kwargs to shortcut (fixes #578)