### PR TITLE
Set zip_safe as False

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,4 +69,5 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
+    zip_safe=False
 )


### PR DESCRIPTION
Set `zip_safe` as `False`, so that setuptools correctly unpacks the package from it's egg when being installed through `setup.py install`.

Without this Django cannot find the templates/static, as they are contained within the egg file iteself, rather than being extracted onto the filesystem