### PR TITLE
Stable/0.3.x: Ability to set "many: false" for list method in YAML docstring

### DIFF
--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -679,8 +679,11 @@ class ViewSetMethodIntrospector(BaseMethodIntrospector):
     @property
     def is_array_response(self):
         """ ViewSet.list methods always return array responses """
-        return (self.method == 'list' or
-                super(ViewSetMethodIntrospector, self).is_array_response)
+        is_array = super(ViewSetMethodIntrospector, self).is_array_response
+        if is_array is False:
+            return False
+        elif is_array or self.method == 'list':
+            return True
 
     def get_http_method(self):
         return self.http_method

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -679,11 +679,8 @@ class ViewSetMethodIntrospector(BaseMethodIntrospector):
     @property
     def is_array_response(self):
         """ ViewSet.list methods always return array responses """
-        is_array = super(ViewSetMethodIntrospector, self).is_array_response
-        if is_array is False:
-            return False
-        elif is_array or self.method == 'list':
-            return True
+        return (self.method == 'list' or
+                super(ViewSetMethodIntrospector, self).is_array_response)
 
     def get_http_method(self):
         return self.http_method


### PR DESCRIPTION
If there is available "many: true" parameter in docstring - 'list' method will be depends on in
If that parameter is missing in docstring - it will be true in default for list
For example, I can return JSON like:
```
{
    collection: [
        {
            name: "Igor",
            age: 22
        },
        {
            name: "Sveta",
            age: 18
        }
    ],
    extra_param: true
}
```
That's why I need ability to change this parameter