### PR TITLE
Stable/0.3.x: Django 1.11 compatibility (render_to_response with RequestContext is deprecated)

### DIFF
--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -5,8 +5,7 @@ from django.conf import settings
 from django.views.generic import View
 from django.utils.safestring import mark_safe
 from django.utils.encoding import smart_text
-from django.shortcuts import render_to_response
-from django.template import RequestContext
+from django.shortcuts import render
 from django.core.exceptions import PermissionDenied
 from .compat import import_string
 
@@ -80,8 +79,7 @@ class SwaggerUIView(View):
                     json.dumps(getattr(settings, 'CSRF_COOKIE_NAME', 'csrftoken'))),
             }
         }
-        response = render_to_response(
-            template_name, RequestContext(request, data))
+        response = render(request, template_name, data)
 
         return response
 


### PR DESCRIPTION
Now one should use `django.shortcuts.render()` which automatically uses `RequestContext` and is backwards-compatible with Django 1.3+. I think this solution is better than the one in #644 which seems to be dropping the request data.