### PR TITLE
Stable/0.3.x: Minimum and maximum are strings as per 1.2 spec

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -365,10 +365,10 @@ class DocumentationGenerator(object):
             max_value = getattr(field, 'max_value', None)
             min_value = getattr(field, 'min_value', None)
             if max_value is not None and data_type == 'integer':
-                f['minimum'] = min_value
+                f['minimum'] = str(min_value)
 
             if max_value is not None and data_type == 'integer':
-                f['maximum'] = max_value
+                f['maximum'] = str(max_value)
 
             # ENUM options
             if choices:


### PR DESCRIPTION
The `/models/.../properties/.../minimum` and `/models/.../properties/.../minimum` should be rendered as strings (not integers) as per [spec v1.2, 4.3.3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/1.2.md#433-data-type-fields). Otherwise the generated specs fail validation.