### PR TITLE
Stable/0.3.x: Parameter descriptions can't be null

### DIFF
--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -421,6 +421,11 @@ class BaseMethodIntrospector(object):
                     parameter['enum'] = [choice[0] for choice
                                          in itertools.chain(multiple_choices)]
                     parameter['type'] = 'enum'
+
+                # description of null is not allowed
+                if parameter['description'] is None:
+                    del parameter['description']
+
                 params.append(parameter)
 
         return params


### PR DESCRIPTION
As per [spec v.1.2, 5.2.4](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/1.2.md#524-parameter-object), the `description` of a Parameter object is either a string (recommended) or does not exist. Nulls in this field make validation fail.