### PR TITLE
Stable/0.3.x: Django 1.10+ compatibility in tests

### DIFF
--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
 from django.conf import settings
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.admindocs.utils import trim_docstring
 from django.test import TestCase
@@ -97,11 +97,11 @@ def parse_json(response):
 
 class HTTPSTest(TestCase):
     def setUp(self):
-        self.url_patterns = patterns(
+        self.url_patterns = [
             '',
             url(r'a-view/?$', MockApiView.as_view(), name='a test view'),
             url(r'^swagger/', include('rest_framework_swagger.urls')),
-        )
+        ]
 
     def test_swagger_view(self):
         urls = import_module(settings.ROOT_URLCONF)
@@ -141,11 +141,10 @@ class DocumentationGeneratorMixin(object):
 @override_settings(**base_path_SETTINGS)
 class OverrideBasePathTest(TestCase):
     def setUp(self):
-        self.url_patterns = patterns(
-            '',
+        self.url_patterns = [
             url(r'a-view/?$', MockApiView.as_view(), name='a test view'),
             url(r'^swagger/', include('rest_framework_swagger.urls')),
-        )
+        ]
 
     def test_api_docs(self):
         from django.utils.six.moves.urllib import parse
@@ -160,8 +159,7 @@ class OverrideBasePathTest(TestCase):
 
 class UrlParserTest(TestCase):
     def setUp(self):
-        self.url_patterns = patterns(
-            '',
+        self.url_patterns = [
             url(r'a-view/?$', MockApiView.as_view(), name='a test view'),
             url(r'b-view$', MockApiView.as_view(), name='a test view'),
             url(r'c-view/$', MockApiView.as_view(), name='a test view'),
@@ -172,7 +170,7 @@ class UrlParserTest(TestCase):
             url(r'view-with-param/(:?<ID>\d+)/?$', MockApiView.as_view(),
                 name='another test view'),
             url(r'a-view-honky/?$', MockApiView.as_view(), name='a test view'),
-        )
+        ]
 
     def test_get_apis(self):
         urlparser = UrlParser()
@@ -219,7 +217,7 @@ class UrlParserTest(TestCase):
         self.assertEqual(len(self.url_patterns), len(apis))
 
     def test_flatten_url_tree_url_import(self):
-        urls = patterns('', url(r'api/base/path/', include(self.url_patterns)))
+        urls = [url(r'api/base/path/', include(self.url_patterns))]
         urlparser = UrlParser()
         apis = urlparser.get_apis(urls)
 
@@ -227,13 +225,12 @@ class UrlParserTest(TestCase):
 
     def test_resources_starting_with_letters_from_base_path(self):
         base_path = r'api/'
-        url_patterns = patterns(
-            '',
+        url_patterns = [
             url(r'test', MockApiView.as_view(), name='a test view'),
             url(r'pai_test', MockApiView.as_view(),
                 name='start with letters a, p, i'),
-        )
-        urls = patterns('', url(base_path, include(url_patterns)))
+        ]
+        urls = [url(base_path, include(url_patterns))]
         urlparser = UrlParser()
         apis = urlparser.get_apis(urls)
         resources = urlparser.get_top_level_apis(apis)
@@ -261,12 +258,11 @@ class UrlParserTest(TestCase):
         self.assertEqual(apis, apis2)
 
     def test_flatten_url_tree_excluded_url_name(self):
-        urls = patterns(
-            '',
+        urls = [
             url(r'a-view/?$', MockApiView.as_view(), name='a test view'),
             url(r'b-view$', MockApiView.as_view(), name='b test view'),
             url(r'excluded-view/$', MockApiView.as_view(), name='excluded_name'),
-        )
+        ]
         urlparser = UrlParser()
         apis = urlparser.__flatten_patterns_tree__(
             patterns=urls, exclude_url_names=['excluded_name'])
@@ -275,11 +271,10 @@ class UrlParserTest(TestCase):
         self.assertEqual(['/a-view/', '/b-view'], [api['path'] for api in apis])
 
     def test_flatten_url_tree_excluded_namesapce(self):
-        urls = patterns(
-            '',
+        urls = [
             url(r'api/base/path/',
                 include(self.url_patterns, namespace='exclude'))
-        )
+        ]
         urlparser = UrlParser()
         apis = urlparser.__flatten_patterns_tree__(
             patterns=urls, exclude_namespaces=['exclude'])
@@ -302,12 +297,11 @@ class UrlParserTest(TestCase):
         router.register(r'other_views', MockApiViewSet)
         router.register(r'more_views', MockApiViewSet)
 
-        urls_app = patterns('', url(r'^', include(router.urls)))
-        urls = patterns(
-            '',
+        urls_app = [url(r'^', include(router.urls))]
+        urls = [
             url(r'api/', include(urls_app)),
             url(r'test/', include(urls_app))
-        )
+        ]
         urlparser = UrlParser()
         apis = urlparser.get_apis(urls)
 
@@ -324,10 +318,9 @@ class UrlParserTest(TestCase):
 
     def test_get_api_callback_not_rest_view(self):
         urlparser = UrlParser()
-        non_api = patterns(
-            '',
+        non_api = [
             url(r'something', NonApiView.as_view())
-        )
+        ]
         callback = urlparser.__get_pattern_api_callback__(non_api)
 
         self.assertIsNone(callback)
@@ -359,7 +352,7 @@ class UrlParserTest(TestCase):
         self.assertEqual(data['pattern'], pattern)
 
     def test_assemble_data_with_non_api_callback(self):
-        bad_pattern = patterns('', url(r'^some_view/', NonApiView.as_view()))
+        bad_pattern = [url(r'^some_view/', NonApiView.as_view())]
 
         urlparser = UrlParser()
         data = urlparser.__assemble_endpoint_data__(bad_pattern)
@@ -407,23 +400,20 @@ class NestedUrlParserTest(TestCase):
             def get(self, request):
                 pass
 
-        api_fuzzy_url_patterns = patterns(
-            '', url(r'^item/$', FuzzyApiView.as_view(), name='find_me'))
-        api_shiny_url_patterns = patterns(
-            '', url(r'^item/$', ShinyApiView.as_view(), name='hide_me'))
+        api_fuzzy_url_patterns = [url(r'^item/$', FuzzyApiView.as_view(), name='find_me')]
+        api_shiny_url_patterns = [url(r'^item/$', ShinyApiView.as_view(), name='hide_me')]
 
-        fuzzy_app_urls = patterns(
-            '', url(r'^api/', include(api_fuzzy_url_patterns,
-                                      namespace='api_fuzzy_app')))
-        shiny_app_urls = patterns(
-            '', url(r'^api/', include(api_shiny_url_patterns,
-                                      namespace='api_shiny_app')))
+        fuzzy_app_urls = [
+            url(r'^api/', include(api_fuzzy_url_patterns, namespace='api_fuzzy_app')),
+        ]
+        shiny_app_urls = [
+            url(r'^api/', include(api_shiny_url_patterns, namespace='api_shiny_app')),
+        ]
 
-        self.project_urls = patterns(
-            '',
+        self.project_urls = [
             url('my_fuzzy_app/', include(fuzzy_app_urls)),
             url('my_shiny_app/', include(shiny_app_urls)),
-        )
+        ]
 
     def test_exclude_nested_urls(self):
 
@@ -448,15 +438,14 @@ class NestedUrlParserTest(TestCase):
 
 class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
     def setUp(self):
-        self.url_patterns = patterns(
-            '',
+        self.url_patterns = [
             url(r'a-view/?$', MockApiView.as_view(), name='a test view'),
             url(r'a-view/child/?$', MockApiView.as_view()),
             url(r'a-view/<pk>/?$', MockApiView.as_view(),
                 name="detailed view for mock"),
             url(r'another-view/?$', MockApiView.as_view(),
                 name='another test view'),
-        )
+        ]
 
     def test_get_operations(self):
         class AnAPIView(APIView):
@@ -466,7 +455,7 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
         api = {
             'path': 'a-path/',
             'callback': AnAPIView,
-            'pattern': patterns('')
+            'pattern': [],
         }
         docgen = self.get_documentation_generator()
         operations = docgen.get_operations(api)
@@ -481,7 +470,7 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
         api = {
             'path': 'a-path/',
             'callback': AnAPIView,
-            'pattern': patterns('')
+            'pattern': [],
         }
 
         docgen = self.get_documentation_generator(for_user=None)
@@ -497,7 +486,7 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
         api = {
             'path': 'a-path/',
             'callback': AnAPIView,
-            'pattern': patterns('')
+            'pattern': [],
         }
 
         swagger_settings = copy.deepcopy(DEFAULT_SWAGGER_SETTINGS)
@@ -515,7 +504,7 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
         api = {
             'path': 'a-path/',
             'callback': AnAPIView,
-            'pattern': patterns('')
+            'pattern': [],
         }
         docgen = self.get_documentation_generator()
         operations = docgen.get_operations(api)
@@ -527,7 +516,7 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
             serializer_class = CommentSerializer
 
         urlparser = UrlParser()
-        url_patterns = patterns('', url(r'my-api/', SerializedAPI.as_view()))
+        url_patterns = [url(r'my-api/', SerializedAPI.as_view())]
         apis = urlparser.get_apis(url_patterns)
 
         docgen = self.get_documentation_generator()
@@ -540,7 +529,7 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
             serializer_class = CommentSerializer
 
         urlparser = UrlParser()
-        url_patterns = patterns('', url(r'my-api/', SerializedAPI.as_view()))
+        url_patterns = [url(r'my-api/', SerializedAPI.as_view())]
         apis = urlparser.get_apis(url_patterns)
 
         docgen = self.get_documentation_generator()
@@ -557,7 +546,7 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
             serializer_class = CommentSerializer
 
         urlparser = UrlParser()
-        url_patterns = patterns('', url(r'my-api/', SerializedAPI.as_view()))
+        url_patterns = [url(r'my-api/', SerializedAPI.as_view())]
         apis = urlparser.get_apis(url_patterns)
 
         docgen = self.get_documentation_generator()
@@ -596,7 +585,7 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
             serializer_class = CommentSerializer
 
         urlparser = UrlParser()
-        url_patterns = patterns('', url(r'my-api/', SerializedAPI.as_view()))
+        url_patterns = [url(r'my-api/', SerializedAPI.as_view())]
         apis = urlparser.get_apis(url_patterns)
 
         docgen = DocumentationGenerator()
@@ -612,7 +601,7 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
             serializer_class = CommentSerializer
 
         urlparser = UrlParser()
-        url_patterns = patterns('', url(r'my-api/', SerializedAPI.as_view()))
+        url_patterns = [url(r'my-api/', SerializedAPI.as_view())]
         apis = urlparser.get_apis(url_patterns)
 
         docgen = self.get_documentation_generator()
@@ -708,10 +697,9 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
                     return SerializerFoo
                 return SerializerBar
         urlparser = UrlParser()
-        url_patterns = patterns(
-            '',
+        url_patterns = [
             url(r'^a/$', TestView.as_view()),
-        )
+        ]
         apis = urlparser.get_apis(url_patterns)
 
         docgen = self.get_documentation_generator()
@@ -720,10 +708,9 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
         self.assertEqual(SerializerBar, list(serializer_set)[0])
 
         urlparser = UrlParser()
-        url_patterns = patterns(
-            '',
+        url_patterns = [
             url(r'^a/b$', TestView.as_view(), {'b': True}),
-        )
+        ]
         apis = urlparser.get_apis(url_patterns)
 
         docgen = self.get_documentation_generator()
@@ -746,7 +733,7 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
                     return SerializerForAnonymous
 
         urlparser = UrlParser()
-        url_patterns = patterns('', url(r'^a/$', TestView.as_view()))
+        url_patterns = [url(r'^a/$', TestView.as_view())]
         apis = urlparser.get_apis(url_patterns)
 
         docs_for_anonymous = self.get_documentation_generator()
@@ -785,7 +772,7 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
                 """
                 return Response({'horse': request.GET.get('horse')})
 
-        url_patterns = patterns('', url(r'my-api/', MyCustomView.as_view()))
+        url_patterns = [url(r'my-api/', MyCustomView.as_view())]
         urlparser = UrlParser()
         apis = urlparser.get_apis(url_patterns)
         generator = self.get_documentation_generator()
@@ -815,8 +802,7 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
             model = User
 
         # Test an object endpoint
-        url_patterns = patterns(
-            '',
+        url_patterns = [
             url(
                 r'^/api/endpoint/(?P<pk>[^/]+)$',
                 MyViewSet.as_view({
@@ -832,7 +818,7 @@ class DocumentationGeneratorTest(TestCase, DocumentationGeneratorMixin):
                     'get': 'list',
                     'post': 'create',
                 }))
-        )
+        ]
         urlparser = UrlParser()
         apis = urlparser.get_apis(url_patterns)
         api = apis[0]
@@ -1365,7 +1351,7 @@ class BaseMethodIntrospectorTest(TestCase, DocumentationGeneratorMixin):
 
         self.assertEqual(len(HiddenSerializer().get_fields()) - 1, len(params))
 
-        url_patterns = patterns('', url(r'my-api/', SerializedAPI.as_view()))
+        url_patterns = [url(r'my-api/', SerializedAPI.as_view())]
         urlparser = UrlParser()
         generator = self.get_documentation_generator()
         apis = urlparser.get_apis(url_patterns)
@@ -1394,7 +1380,7 @@ class BaseMethodIntrospectorTest(TestCase, DocumentationGeneratorMixin):
             len(params))
         self.assertEqual(params[0]['name'], 'email')
 
-        url_patterns = patterns('', url(r'my-api/', SerializedAPI.as_view()))
+        url_patterns = [url(r'my-api/', SerializedAPI.as_view())]
         urlparser = UrlParser()
         generator = self.get_documentation_generator()
         apis = urlparser.get_apis(url_patterns)
@@ -2039,7 +2025,7 @@ class YAMLDocstringParserTests(TestCase, DocumentationGeneratorMixin):
         introspector = APIViewMethodIntrospector(class_introspector, 'POST')
         generator = self.get_documentation_generator()
         serializer = generator._get_method_serializer(introspector)
-        url_patterns = patterns('', url(r'my-api/', SerializedAPI.as_view()))
+        url_patterns = [url(r'my-api/', SerializedAPI.as_view())]
         urlparser = UrlParser()
         apis = urlparser.get_apis(url_patterns)
         models = generator.get_models(apis)
@@ -2361,7 +2347,7 @@ class YAMLDocstringParserTests(TestCase, DocumentationGeneratorMixin):
             return "blarg"
 
         class_introspector = self.make_fbv_introspector(a_view)
-        url_patterns = patterns('', url(r'my-api/', a_view))
+        url_patterns = [url(r'my-api/', a_view)]
         urlparser = UrlParser()
         generator = self.get_documentation_generator()
         apis = urlparser.get_apis(url_patterns)
@@ -2401,7 +2387,7 @@ class YAMLDocstringParserTests(TestCase, DocumentationGeneratorMixin):
                 """
                 return Response({'horse': request.GET.get('horse')})
 
-        url_patterns = patterns('', url(r'my-api/', MyCustomView.as_view()))
+        url_patterns = [url(r'my-api/', MyCustomView.as_view())]
         urlparser = UrlParser()
         apis = urlparser.get_apis(url_patterns)
         generator = self.get_documentation_generator()
@@ -2453,7 +2439,7 @@ class YAMLDocstringParserTests(TestCase, DocumentationGeneratorMixin):
             return Response("o noes!")
         generator = self.get_documentation_generator()
         urlparser = UrlParser()
-        url_patterns = patterns('', url(r'my-api/', a_view))
+        url_patterns = [url(r'my-api/', a_view)]
         apis = urlparser.get_apis(url_patterns)
         serializers = generator._get_serializer_set(apis)
         self.assertIn(CommentSerializer, serializers)
@@ -2461,7 +2447,7 @@ class YAMLDocstringParserTests(TestCase, DocumentationGeneratorMixin):
         api = {
             'path': 'a-path/',
             'callback': func_to_wrapper(a_view),
-            'pattern': patterns('')
+            'pattern': [],
         }
         operations = generator.get_operations(api)
         self.assertEqual(len(operations), 1)

--- a/tests/cigar_example/cigar_example/restapi/urls.py
+++ b/tests/cigar_example/cigar_example/restapi/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from rest_framework.routers import DefaultRouter
 
 from cigar_example.restapi import views as views
@@ -8,8 +8,7 @@ router = DefaultRouter()
 router.register(r'cigars', views.CigarViewSet)
 router.register(r'artisan_cigars', views.ArtisanCigarViewSet)
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     # Examples:
     url(r'^custom$', views.MyCustomView.as_view()),
     url(r'^manufacturers/?$', views.ManufacturerList.as_view(), name='list_of_manufacturers'),
@@ -23,6 +22,6 @@ urlpatterns = patterns(
     url(r'^drop_cigar_in_jambalaya/$', views.drop_cigar_in_jambalaya, name='cigar-jambalaya'),
     url(r'^mix_cigars_in_jambalaya/$', views.mix_cigars_in_jambalaya, name='mix-cigars-jambalaya'),
     url(r'^custom_create/$', views.create_cigar2, name='custom-create-cigar'),
-)
+]
 
 urlpatterns += router.urls

--- a/tests/cigar_example/cigar_example/urls.py
+++ b/tests/cigar_example/cigar_example/urls.py
@@ -1,11 +1,10 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
-    (r'^api/', include('cigar_example.restapi.urls', namespace="cigars")),
-    (r'^', include('rest_framework_swagger.urls', namespace='swagger'))
-)
+    url(r'^api/', include('cigar_example.restapi.urls', namespace="cigars")),
+    url(r'^', include('rest_framework_swagger.urls', namespace='swagger')),
+]


### PR DESCRIPTION
`django.conf.urls.patterns()` is deprecated since 1.8 and removed in 1.10. It was only used in tests, though.