### PR TITLE
Stable/0.3.x: Fix @api_view wrapper detection on DRF 3.4.7+

### DIFF
--- a/rest_framework_swagger/decorators.py
+++ b/rest_framework_swagger/decorators.py
@@ -54,3 +54,17 @@ def wrapper_to_func(wrapper):
 
 def func_to_wrapper(func):
     return func.cls
+
+
+def is_api_view_wrapper(wrapper):
+    try:
+        noms = wrapper.http_method_names
+        handlers = [getattr(wrapper, m) for m in noms if m != 'options']
+    except AttributeError:
+        return False
+    if not handlers or handlers.count(handlers[0]) != len(handlers):
+        return False
+    code = six.get_function_code(handlers[0])
+    return (code.co_filename.endswith('decorators.py') and
+            code.co_name == 'handler' and
+            code.co_freevars == ('func',))

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -16,6 +16,7 @@ from .introspectors import (
     get_primitive_type
 )
 from .compat import OrderedDict
+from .decorators import is_api_view_wrapper
 
 
 class DocumentationGenerator(object):
@@ -59,7 +60,7 @@ class DocumentationGenerator(object):
         path = api['path']
         pattern = api['pattern']
         callback = api['callback']
-        if callback.__module__ == 'rest_framework.decorators':
+        if is_api_view_wrapper(callback):
             return WrappedAPIViewIntrospector(callback, path, pattern, self.user)
         elif issubclass(callback, viewsets.ViewSetMixin):
             patterns = [a['pattern'] for a in apis


### PR DESCRIPTION
Since the merge of https://github.com/encode/django-rest-framework/commit/5df54a711f3770de28c0aaed9350e589df082117, functions wrapped with `@api_view` decorator could no longer be detected which resulted in failing tests.