### PR TITLE
Stable/0.3.x: enum is not a primitive type per 1.2 spec

### DIFF
--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -418,9 +418,7 @@ class BaseMethodIntrospector(object):
                 normalize_data_format(data_type, None, parameter)
                 multiple_choices = filter_.extra.get('choices', {})
                 if multiple_choices:
-                    parameter['enum'] = [choice[0] for choice
-                                         in itertools.chain(multiple_choices)]
-                    parameter['type'] = 'enum'
+                    parameter['enum'] = [choice[0] for choice in multiple_choices]
                 params.append(parameter)
 
         return params

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -1099,7 +1099,7 @@ class ViewSetMethodIntrospectorTests(TestCase):
                            'name': 'choices',
                            'description': 'Choices of possible first names',
                            'enum': ['foo', 'bar'],
-                           'type': 'enum'
+                           'type': 'string'
                            }
                           ])
 


### PR DESCRIPTION
[Spec v.1.2, 5.2.4](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/1.2.md#433-data-type-fields) says explicitly:
>  `enum` may only be included if the `type` field is set to `string`.
It was set to `enum`, and buggy test code existed to test it.