### PR TITLE
Fix 660

### DIFF
--- a/rest_framework_swagger/static/rest_framework_swagger/swagger-ui.js
+++ b/rest_framework_swagger/static/rest_framework_swagger/swagger-ui.js
@@ -1209,7 +1209,8 @@ ApiKeyAuthorization.prototype.apply = function (obj) {
     return true;
   } else if (this.type === 'header') {
     if(typeof obj.headers[this.name] === 'undefined') {
-      obj.headers[this.name] = this.value;
+      if (window.swaggerUi.api.securityDefinitions.api_key.prefix_token != null)
+        obj.headers[this.name] = window.swaggerUi.api.securityDefinitions.api_key.prefix_token + this.value;
     }
 
     return true;


### PR DESCRIPTION
It must fix #660. It's a simple hack, not sure it's the better way to do this.

I also added an option to add a prefix for the `Authorization` payload in the header, named `prefix_token`.

I didn't generate the minified JS file because I don't know how to do this. Can someone tell me before merging?