### PR TITLE
Add title block so page title can be overwritten

### DIFF
--- a/rest_framework_swagger/templates/rest_framework_swagger/base.html
+++ b/rest_framework_swagger/templates/rest_framework_swagger/base.html
@@ -3,7 +3,9 @@
 <html>
 <head>
   <meta charset="UTF-8">
+  {% block title %}
   <title>Swagger UI</title>
+  {% endblock %}
   <link rel="icon" type="image/png" href="{% static 'rest_framework_swagger/images/favicon-32x32.png' %}" sizes="32x32" />
   <link rel="icon" type="image/png" href="{% static 'rest_framework_swagger/images/favicon-16x16.png' %}" sizes="16x16" />
   <link href='{% static "rest_framework_swagger/css/typography.css" %}' media='screen' rel='stylesheet' type='text/css'/>


### PR DESCRIPTION
I've just wrapped the <title> tag with a block so it can be easily overwritten without having to replace the entire base.html.