### PR TITLE
Django 1.11 fix for 0.3.x (non-dict context)

### DIFF
--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -1,4 +1,5 @@
 import json
+from django import VERSION as DJANGO_VERSION
 from django.utils import six
 
 from django.conf import settings
@@ -6,7 +7,8 @@ from django.views.generic import View
 from django.utils.safestring import mark_safe
 from django.utils.encoding import smart_text
 from django.shortcuts import render_to_response
-from django.template import RequestContext
+if DJANGO_VERSION < (1, 11):
+    from django.template import RequestContext
 from django.core.exceptions import PermissionDenied
 from .compat import import_string
 
@@ -80,8 +82,12 @@ class SwaggerUIView(View):
                     json.dumps(getattr(settings, 'CSRF_COOKIE_NAME', 'csrftoken'))),
             }
         }
-        response = render_to_response(
-            template_name, RequestContext(request, data))
+        if DJANGO_VERSION < (1, 11):
+            response = render_to_response(
+                template_name, RequestContext(request, data))
+        else:
+            data['request'] = request # Not sure if we need to append request?
+            response = render_to_response(template_name, data)
 
         return response
 

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -86,7 +86,7 @@ class SwaggerUIView(View):
             response = render_to_response(
                 template_name, RequestContext(request, data))
         else:
-            data['request'] = request # Not sure if we need to append request?
+            data['request'] = request
             response = render_to_response(template_name, data)
 
         return response


### PR DESCRIPTION
Small fix for `render()` changes in Django 1.11. From the [changelog](https://docs.djangoproject.com/en/1.11/releases/1.11/#django-template-backends-django-template-render-prohibits-non-dict-context):
> **django.template.backends.django.Template.render() prohibits non-dict context**
> For compatibility with multiple template engines, django.template.backends.django.Template.render() (returned from high-level template loader APIs such as loader.get_template()) must receive a dictionary of context rather than Context or RequestContext. If you were passing either of the two classes, pass a dictionary instead – doing so is backwards-compatible with older versions of Django.

The change uses a dict for Django 1.11 and up and inserts `request` into the dict (which should only be required if the request context processor is not loaded).