### PR TITLE
Stable/0.3.x: Schema object's `required` field cannot be empty

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -165,6 +165,8 @@ class DocumentationGenerator(object):
                 'required': [i for i in data['required'] if i in w_properties.keys()],
                 'properties': w_properties,
             }
+            if not models[w_name]['required']:
+                del models[w_name]['required']
 
             # Reading
             # no write_only fields
@@ -178,6 +180,8 @@ class DocumentationGenerator(object):
                 'required': [i for i in r_properties.keys()],
                 'properties': r_properties,
             }
+            if not models[r_name]['required']:
+                del models[r_name]['required']
 
             # Enable original model for testing purposes
             # models[serializer_name] = {


### PR DESCRIPTION
According to JSON Schema specification, `required` field of a schema object is a [stringArray](http://json-schema.org/draft-04/schema#/definitions/stringArray) which means it should have at least one element. So skip the `required` field if there are no required properties, to make schema validation pass.