### PR TITLE
Stable/0.3.x: Property objects cannot have a `required` field

### DIFF
--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -348,7 +348,6 @@ class DocumentationGenerator(object):
                 'description': description,
                 'type': data_type,
                 'format': data_format,
-                'required': getattr(field, 'required', False),
                 'defaultValue': get_default_value(field),
                 'readOnly': getattr(field, 'read_only', None),
             }


### PR DESCRIPTION
As per [spec v.1.2, 5.2.9](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/1.2.md#529-property-object), and [4.3.3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/1.2.md#433-data-type-fields), Property objects don't contain a `required` field. This PR removes it to make validation pass. The information is still included in the model's `required` field.