### PR TITLE
Stable/0.3.x: Make tests pass with Django 1.11+

### DIFF
--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -1098,7 +1098,8 @@ class ViewSetMethodIntrospectorTests(TestCase):
                           {'paramType': 'query',
                            'name': 'choices',
                            'description': 'Choices of possible first names',
-                           'enum': ['foo', 'bar'],
+                           'enum': (['', 'foo', 'bar'] if django_filters.__version__ >= '1.0.0'
+                                    else ['foo', 'bar']),
                            'type': 'enum'
                            }
                           ])

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -5,8 +5,7 @@ from django.conf import settings
 from django.views.generic import View
 from django.utils.safestring import mark_safe
 from django.utils.encoding import smart_text
-from django.shortcuts import render_to_response
-from django.template import RequestContext
+from django.shortcuts import render
 from django.core.exceptions import PermissionDenied
 from .compat import import_string
 
@@ -80,8 +79,7 @@ class SwaggerUIView(View):
                     json.dumps(getattr(settings, 'CSRF_COOKIE_NAME', 'csrftoken'))),
             }
         }
-        response = render_to_response(
-            template_name, RequestContext(request, data))
+        response = render(request, template_name, data)
 
         return response
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,19 @@
 [tox]
 envlist =
     py27-flake8,
-    {py27,py35}-django{1.8,1.9}-drf{3.3,3.4},
+    {py27,py35}-django{1.8,1.9,1.10,1.11}-drf{3.3,3.4,3.5,3.6},
 
 [testenv]
 commands = ./runtests.py --stop
 deps =
     django1.8: Django>=1.8,<1.9
     django1.9: Django>=1.9,<1.10
+    django1.10: Django>=1.10,<1.11
+    django1.11: Django>=1.11,<1.12
     drf3.3: djangorestframework>=3.3,<3.4
-    drf3.4: djangorestframework>=3.4
+    drf3.4: djangorestframework>=3.4,<3.5
+    drf3.5: djangorestframework>=3.5,<3.6
+    drf3.6: djangorestframework>=3.6,<3.7
     {py27,py33,py34}-django{1.8}-drf{2.3,2.4}: PyYAML==3.10
     py27: functools32==3.2.3-2
     docutils==0.11
@@ -20,7 +24,8 @@ deps =
     mock==1.0.1
     django-nose==1.4.4
     coverage==3.6
-    django-filter==0.10.0
+    django{1.8,1.9,1.10}: django-filter==0.10.0
+    django1.11: django-filter>=1.0.2
     jsonschema==2.5
 
 [testenv:py27-flake8]


### PR DESCRIPTION
This PR fixes tests on Django 1.11+. It should be merged only after #650 and #653 are merged.