### PR TITLE
Stable/0.3.x: form parameter minimum/maximum values are strings per 1.2 spec

### DIFF
--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -486,10 +486,10 @@ class BaseMethodIntrospector(object):
             max_value = getattr(field, 'max_value', None)
             min_value = getattr(field, 'min_value', None)
             if max_value is not None and data_type == 'integer':
-                f['minimum'] = min_value
+                f['minimum'] = str(min_value)
 
             if max_value is not None and data_type == 'integer':
-                f['maximum'] = max_value
+                f['maximum'] = str(max_value)
 
             # ENUM options
             if choices:

--- a/rest_framework_swagger/tests.py
+++ b/rest_framework_swagger/tests.py
@@ -1799,6 +1799,27 @@ class YAMLDocstringParserTests(TestCase, DocumentationGeneratorMixin):
         self.assertIn('maximum', params[0])
         self.assertEqual(params[0]['maximum'], '100')
 
+    def test_parameters_minimum_is_string_with_introspection(self):
+        '''
+        minimum and maximum of Parameter Object required by
+        Swagger 1.2 spec to be string.
+        '''
+        class CommentSerializer(serializers.Serializer):
+            some_bigint = serializers.IntegerField(min_value=1, max_value=100)
+
+        class SerializedAPI(ListCreateAPIView):
+            serializer_class = CommentSerializer
+
+        class_introspector = self.make_introspector(SerializedAPI)
+        introspector = APIViewMethodIntrospector(class_introspector, 'POST')
+        parser = introspector.get_yaml_parser()
+        params = parser.discover_parameters(introspector)
+        self.assertEqual(len(params), 1)
+        self.assertIn('minimum', params[0])
+        self.assertEqual(params[0]['minimum'], '1')
+        self.assertIn('maximum', params[0])
+        self.assertEqual(params[0]['maximum'], '100')
+
     def test_response_messages(self):
         class SerializedAPI(ListCreateAPIView):
             serializer_class = CommentSerializer


### PR DESCRIPTION
According to [spec 1.2, 4.3.3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/1.2.md#433-data-type-fields), `minimum` and `maximum` fields are strings. Added a test and a fix to make sure this happens with parameters gathered by serializer introspection. 