### PR TITLE
Added possibility to use custom schema generator

### DIFF
--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -8,7 +8,8 @@ from rest_framework.views import APIView
 from . import renderers
 
 
-def get_swagger_view(title=None, url=None, patterns=None, urlconf=None):
+def get_swagger_view(title=None, url=None, patterns=None, urlconf=None,
+                     schema_generator_cls=None):
     """
     Returns schema view which renders Swagger/OpenAPI.
     """
@@ -23,7 +24,12 @@ def get_swagger_view(title=None, url=None, patterns=None, urlconf=None):
         ]
 
         def get(self, request):
-            generator = SchemaGenerator(
+            if schema_generator_cls is None:
+                generator_cls = SchemaGenerator
+            else:
+                generator_cls = schema_generator_cls
+
+            generator = generator_cls(
                 title=title,
                 url=url,
                 patterns=patterns,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -7,7 +7,7 @@ from rest_framework.test import APIRequestFactory
 from rest_framework_swagger import renderers
 from rest_framework_swagger.views import get_swagger_view
 
-from .compat.mock import patch
+from .compat.mock import patch, MagicMock
 
 
 class TestGetSwaggerView(TestCase):
@@ -15,6 +15,31 @@ class TestGetSwaggerView(TestCase):
         self.sut = get_swagger_view
         self.factory = APIRequestFactory()
         self.view_class = self.sut().cls
+
+    def test_custom_schema_generator_used(self):
+        title = 'Vandelay'
+        url = 'https://github.com/marcgibbons/django-rest-swagger'
+        urlconf = 'fizz'
+        patterns = []
+
+        schema_generator = MagicMock()
+        view = self.sut(
+            title=title,
+            url=url,
+            patterns=patterns,
+            urlconf=urlconf,
+            schema_generator_cls=schema_generator
+        )
+
+        request = self.factory.get('/')
+        view(request=request)
+
+        schema_generator.assert_called_once_with(
+            title=title,
+            url=url,
+            patterns=patterns,
+            urlconf=urlconf
+        )
 
     def test_title_and_urlpassed_to_schema_generator(self):
         title = 'Vandelay'


### PR DESCRIPTION
It would be handy if it would be possible to use custom schema generator without need to define a view seperately