### PR TITLE
Correct filename

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ the schemas section.
 
 #### Example
 
-**views.py**
+**urls.py**
 ```python
 from django.conf.urls import url
 from rest_framework_swagger.views import get_swagger_view


### PR DESCRIPTION
Should this be `urls.py`? I know it's referring to the schema view, but `urlpatterns` are generally in `urls.py`.