### PR TITLE
Allow the apps to specify permissions

### DIFF
--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -8,7 +8,7 @@ from rest_framework.views import APIView
 from . import renderers
 
 
-def get_swagger_view(title=None, url=None, patterns=None, urlconf=None):
+def get_swagger_view(title=None, url=None, patterns=None, urlconf=None, permission_classes=None):
     """
     Returns schema view which renders Swagger/OpenAPI.
     """
@@ -38,4 +38,8 @@ def get_swagger_view(title=None, url=None, patterns=None, urlconf=None):
 
             return Response(schema)
 
+    if permission_classes:
+        SwaggerSchemaView.permission_classes = permission_classes
+
     return SwaggerSchemaView.as_view()
+


### PR DESCRIPTION
Allow the consuming apps to specify permissions on swagger view class itself rather than the current fixed "AllowAny". For certain app deployment environments this ability is much needed.

Example:

`my_docs_view = get_swagger_view(title='XYZ Web Services API', permission_classes=[IsAuthenticated, ])`
