### PR TITLE
removed extra Docker mention from the docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ password: amy
 
 ### Docker Instructions
 
-Ensure [Docker](https://www.docker.com/) Docker is installed on your system.
+Ensure [Docker](https://www.docker.com/) is installed on your system.
 
 First, clone the repository:
 


### PR DESCRIPTION
Currently, the docs say:

> Ensure Docker Docker is installed on your system.

where first `Docker` mention is a link. This PR removes the second `Docker` that is not a link.