### PR TITLE
Adds editable title tag in index.html

### DIFF
--- a/rest_framework_swagger/settings.py
+++ b/rest_framework_swagger/settings.py
@@ -26,7 +26,8 @@ DEFAULTS = {
     ],
     'VALIDATOR_URL': '',
     'ACCEPT_HEADER_VERSION': None,  # e.g. '1.0'
-    'CUSTOM_HEADERS': {}  # A dictionary of key/vals to override headers
+    'CUSTOM_HEADERS': {},  # A dictionary of key/vals to override headers
+    'INDEX_PAGE_TITLE_TAG': 'Swagger UI'
 }
 
 IMPORT_STRINGS = []

--- a/rest_framework_swagger/templates/rest_framework_swagger/index.html
+++ b/rest_framework_swagger/templates/rest_framework_swagger/index.html
@@ -4,7 +4,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Swagger UI</title>
+  <title>{{ INDEX_PAGE_TITLE_TAG }}</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
   <link href="{% static 'rest_framework_swagger/bundles/vendors.bundle.css' %}" rel="stylesheet" type="text/css">
   <link href="{% static 'rest_framework_swagger/bundles/app.bundle.css' %}" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Added an editable title tag in index.html by using Swagger settings. Default value will remain the same for those users who have not added the new configuration.

closes https://github.com/marcgibbons/django-rest-swagger/issues/668