### PR TITLE
Removed using of deprecated assertDictContainsSubset().

### DIFF
--- a/tests/renderers/test_openapi_renderer.py
+++ b/tests/renderers/test_openapi_renderer.py
@@ -95,10 +95,9 @@ class TestGetCustomizations(TestCase):
 
     def test_security_definitions_included_when_defined(self):
         self.swagger_settings.SECURITY_DEFINITIONS = {'foo': 'bar'}
-        expected = {
-            'securityDefinitions': self.swagger_settings.SECURITY_DEFINITIONS
-        }
-        self.assertDictContainsSubset(expected, self.sut())
+        sut = self.sut()
+        self.assertIn('securityDefinitions', sut)
+        self.assertEqual(sut['securityDefinitions'], self.swagger_settings.SECURITY_DEFINITIONS)
 
     def test_security_definitions_not_present_when_none(self):
         self.swagger_settings.SECURITY_DEFINITIONS = None

--- a/tests/renderers/test_swagger.py
+++ b/tests/renderers/test_swagger.py
@@ -68,8 +68,8 @@ class TestSwaggerUIRenderer(TestCase):
         urls = {'fizz': 'buzz'}
         with patch.object(self.sut, 'get_auth_urls', return_value=urls):
             self.sut.set_context(data, self.renderer_context)
-
-        self.assertDictContainsSubset(urls, self.renderer_context)
+        self.assertIn('fizz', self.renderer_context)
+        self.assertEqual(self.renderer_context['fizz'], 'buzz')
 
     def test_set_context_sets_ui_settings(self):
         data = MagicMock()
@@ -136,8 +136,8 @@ class TestSwaggerUIRenderer(TestCase):
     def test_validator_url_none_when_set(self):
         self.swagger_settings.VALIDATOR_URL = None
         result = self.sut.get_ui_settings()
-
-        self.assertDictContainsSubset({'validatorUrl': None}, result)
+        self.assertIn('validatorUrl', result)
+        self.assertIsNone(result['validatorUrl'])
 
     def test_validator_url_not_present_when_empty_string(self):
         """


### PR DESCRIPTION
Deprecated since Python 3.2 (see [release notes](https://docs.python.org/3/whatsnew/3.2.html)).