### PR TITLE
Fix excluding schema view from doc page for DRF 3.9

### DIFF
--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -15,6 +15,7 @@ def get_swagger_view(title=None, url=None, patterns=None, urlconf=None):
     class SwaggerSchemaView(APIView):
         _ignore_model_permissions = True
         exclude_from_schema = True
+        schema = None
         permission_classes = [AllowAny]
         renderer_classes = [
             CoreJSONRenderer,


### PR DESCRIPTION
From Django REST framework documentation:
```
Both APIView.exclude_from_schema and the exclude_from_schema argument be moved to deprecated in the 3.8 release, and removed entirely in 3.9.
```