### PR TITLE
FIXES #815 -- template tag (staticfiles) is deprecated in Django 2.2

### DIFF
--- a/rest_framework_swagger/templates/rest_framework_swagger/index.html
+++ b/rest_framework_swagger/templates/rest_framework_swagger/index.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
and was deprecated in 2.2
