### PR TITLE
change staticfiles tag to static

### DIFF
--- a/rest_framework_swagger/templates/rest_framework_swagger/index.html
+++ b/rest_framework_swagger/templates/rest_framework_swagger/index.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
The index.html file in the templates folder contains a  load "staticfiles" import which I assume is for using the static tag. 

However, this returns an error since this isn't the load command django recommends for static files. Hence, I changed: 

`{% load staticfiles %}` 

to

` {% load static %}`.


After this, it no longer throws the error of not recognizing the _load staticfiles_ import.