### PR TITLE
Update index.html

### DIFF
--- a/rest_framework_swagger/templates/rest_framework_swagger/index.html
+++ b/rest_framework_swagger/templates/rest_framework_swagger/index.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
{% load staticfiles %} and {% load admin_static %} were deprecated in Django 2.1, and removed in Django 3.0.
I propose to change it with {% load static %}